### PR TITLE
Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c: create Lo…

### DIFF
--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -104,9 +104,10 @@ DasharoSystemFeaturesUiLibConstructor (
         sizeof (mLockBiosDefault),
         &mLockBiosDefault
         );
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios = mLockBiosDefault;
   }
 
-  if (Status) {
+  if (EFI_ERROR(Status)) {
     return Status;
   }
 

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause
 STATIC EFI_GUID mDasharoSystemFeaturesGuid = DASHARO_SYSTEM_FEATURES_FORMSET_GUID;
 STATIC CHAR16 mVarStoreName[] = L"FeaturesData";
 STATIC CHAR16 mLockBitsEfiVar[] = L"LockBios";
+STATIC BOOLEAN mLockBiosDefault = TRUE;
 
 STATIC DASHARO_SYSTEM_FEATURES_PRIVATE_DATA  mDasharoSystemFeaturesPrivate = {
   DASHARO_SYSTEM_FEATURES_PRIVATE_DATA_SIGNATURE,
@@ -94,7 +95,18 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios
       );
-  if (Status != EFI_NOT_FOUND) {
+
+  if (Status == EFI_NOT_FOUND) {
+    Status = gRT->SetVariable (
+        mLockBitsEfiVar,
+        &mDasharoSystemFeaturesGuid,
+        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+        sizeof (mLockBiosDefault),
+        &mLockBiosDefault
+        );
+  }
+
+  if (Status) {
     return Status;
   }
 


### PR DESCRIPTION
…ckBios var in library constructor

Create BiosLock variable if it's not found in the constructor. Match the default Enabled state as in https://github.com/Dasharo/coreboot/pull/196/files/04d6b5210735d58d178b8c67e123660d456ff4c3#diff-b052138bda366b1aac77b7382aed80b0122b22691a9ac9a68370c8367b5b0a3aR34

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>