### PR TITLE
Oc wdt update

### DIFF
--- a/DasharoModulePkg.dec
+++ b/DasharoModulePkg.dec
@@ -49,7 +49,8 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable|FALSE|BOOLEAN|0x00000009
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise|FALSE|BOOLEAN|0x0000000A
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions|FALSE|BOOLEAN|0x0000000B
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault|500|UINT16|0x0000000C
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions|FALSE|BOOLEAN|0x0000000C
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault|500|UINT16|0x0000000D
 
 [PcdsFixedAtBuild,PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   ## Indicate whether the password is cleared.

--- a/DasharoModulePkg.dec
+++ b/DasharoModulePkg.dec
@@ -49,6 +49,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable|FALSE|BOOLEAN|0x00000009
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise|FALSE|BOOLEAN|0x0000000A
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions|FALSE|BOOLEAN|0x0000000B
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault|500|UINT16|0x0000000C
 
 [PcdsFixedAtBuild,PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   ## Indicate whether the password is cleared.

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -925,6 +925,14 @@ DasharoSystemFeaturesCallback (
           Value->b = PcdGetBool (PcdDefaultNetworkBootEnable);
           break;
         }
+      case 0x1102:
+        {
+          if (Value == NULL)
+            return EFI_INVALID_PARAMETER;
+
+          Value->u16 = FixedPcdGet16 (PcdOcWdtTimeoutDefault);
+          break;
+        }
       default:
         Status = EFI_UNSUPPORTED;
         break;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -69,3 +69,4 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -69,4 +69,5 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions
   gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -192,14 +192,14 @@ formset
 
       suppressif ideqval FeaturesData.WatchdogConfig.WatchdogEnable == 0;
         numeric varid   = FeaturesData.WatchdogConfig.WatchdogTimeout,
+                questionid = 0x1102,
                 prompt  = STRING_TOKEN(STR_WATCHDOG_TIMEOUT_PROMPT),
                 help    = STRING_TOKEN(STR_WATCHDOG_TIMEOUT_HELP),
-                flags   = RESET_REQUIRED,
+                flags   = RESET_REQUIRED | INTERACTIVE,
                 minimum = 300,
                 maximum = 1024,
                 step    = 0,        // Stepping of 0 equates to a manual entering
                                     // of a value, otherwise it will be adjusted by "+"/"-"
-                default = 300,
         endnumeric;
       endif;
     endif;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -185,6 +185,7 @@ formset
 
     suppressif ideqval FeaturesData.WatchdogState == 0;
       checkbox varid   = FeaturesData.WatchdogConfig.WatchdogEnable,
+               questionid = 0x1102,
                prompt  = STRING_TOKEN(STR_WATCHDOG_ENABLE_PROMPT),
                help    = STRING_TOKEN(STR_WATCHDOG_ENABLE_HELP),
                flags   = CHECKBOX_DEFAULT | RESET_REQUIRED,
@@ -192,7 +193,7 @@ formset
 
       suppressif ideqval FeaturesData.WatchdogConfig.WatchdogEnable == 0;
         numeric varid   = FeaturesData.WatchdogConfig.WatchdogTimeout,
-                questionid = 0x1102,
+                questionid = 0x1103,
                 prompt  = STRING_TOKEN(STR_WATCHDOG_TIMEOUT_PROMPT),
                 help    = STRING_TOKEN(STR_WATCHDOG_TIMEOUT_HELP),
                 flags   = RESET_REQUIRED | INTERACTIVE,


### PR DESCRIPTION
The changes allow to pass the default OC WDT timeout via PCD (e.g. one can use coreboot Kconfig option to set the PCD, like here: https://github.com/Dasharo/coreboot/commit/a318679aa67185d1d34ae0469b22fd311d6800df), so that it will work with any provided default timeout, instead of hardcoding in VFR. Also it removes the dependency on the OC WDT register in the ACPI I/O space, which is Intel-specific.