### PR TITLE
Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures: add FUM

### DIFF
--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -28,6 +28,7 @@ STATIC CHAR16 mWatchdogStateEfiVar[] = L"WatchdogAvailable";
 STATIC CHAR16 mFanCurveOptionEfiVar[] = L"FanCurveOption";
 STATIC CHAR16 mIommuConfigEfiVar[] = L"IommuConfig";
 STATIC CHAR16 mSleepTypeEfiVar[] = L"SleepType";
+STATIC CHAR16 mFirmwareUpdateModeEfiVar[] = L"FirmwareUpdateMode";
 
 STATIC BOOLEAN   mUsbStackDefault = TRUE;
 STATIC BOOLEAN   mUsbMassStorageDefault = TRUE;
@@ -876,7 +877,10 @@ DasharoSystemFeaturesCallback (
   )
 {
   EFI_STATUS                                 Status;
+  EFI_INPUT_KEY                              Key;
+  BOOLEAN                                    Enable;
 
+  Enable = TRUE;
   Status = EFI_SUCCESS;
 
   switch (Action) {
@@ -914,6 +918,42 @@ DasharoSystemFeaturesCallback (
       }
       break;
     }
+  case EFI_BROWSER_ACTION_CHANGED:
+    {
+      if (QuestionId == 0x1330) {
+        do {
+          CreatePopUp (
+            EFI_BLACK | EFI_BACKGROUND_RED,
+            &Key,
+            L"",
+            L"You are about to enable Firmware Update Mode.",
+            L"This will turn off all flash protection mechanisms",
+            L"for the duration of next boot.",
+            L"",
+            L"Press ENTER to continue and reboot or ESC to cancel...",
+            L"",
+            NULL
+            );
+        } while ((Key.ScanCode != SCAN_ESC) && (Key.UnicodeChar != CHAR_CARRIAGE_RETURN));
+
+        if (Key.UnicodeChar == CHAR_CARRIAGE_RETURN) {
+          Status = gRT->SetVariable (
+              mFirmwareUpdateModeEfiVar,
+              &gDasharoSystemFeaturesGuid,
+              EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+              sizeof (Enable),
+              &Enable
+              );
+          if (EFI_ERROR (Status)) {
+            return Status;
+          }
+          gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
+        }
+      } else {
+        Status = EFI_UNSUPPORTED;
+      }
+    }
+    break;
   default:
     Status = EFI_UNSUPPORTED;
     break;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.h
@@ -29,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause
 #include <Library/HiiLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/UefiHiiServicesLib.h>
+#include <Library/UefiLib.h>
 
 #include "DasharoSystemFeaturesHii.h"
 

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -32,6 +32,9 @@
 #string STR_DASHARO_POWER_CONFIGURATION_TITLE   #language en-US  "Power Management Options"
 #string STR_DASHARO_POWER_CONFIGURATION_HELP    #language en-US  "Power management-related options"
 
+#string STR_FUM_PROMPT   #language en-US  "Enter Firmware Update Mode"
+#string STR_FUM_HELP     #language en-US  "Disables all firmware protections for the duration of next boot."
+
 #string STR_LOCK_BIOS_PROMPT   #language en-US  "Lock the BIOS boot medium"
 #string STR_LOCK_BIOS_HELP     #language en-US  "Locks the recovery partition of vboot"
 

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -68,6 +68,12 @@ formset
 
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
 
+    text
+      help  = STRING_TOKEN(STR_FUM_HELP),
+      text  = STRING_TOKEN(STR_FUM_PROMPT),
+      flags = INTERACTIVE,
+      key   = 0x1330;
+
     checkbox varid  = FeaturesData.LockBios,
              prompt = STRING_TOKEN(STR_LOCK_BIOS_PROMPT),
              help   = STRING_TOKEN(STR_LOCK_BIOS_HELP),


### PR DESCRIPTION
This commit adds option in security menu to enable Firmware Update Mode. As a result, UEFI variable is set, which will be later caught by coreboot and acted upon to disable firmware write protections.