### PR TITLE
DasharoModulePkg: add option for battery thresholds

### DIFF
--- a/DasharoModulePkg.dec
+++ b/DasharoModulePkg.dec
@@ -55,6 +55,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowSleepType|TRUE|BOOLEAN|0x0000000F
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPciMenu|FALSE|BOOLEAN|0x00000010
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPciMenuShowResizeableBars|FALSE|BOOLEAN|0x00000011
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowBatteryThresholds|FALSE|BOOLEAN|0x00000012
 
 [PcdsFixedAtBuild,PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   ## Indicate whether the password is cleared.

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -33,9 +33,13 @@ STATIC CHAR16 mPowerFailureStateEfiVar[] = L"PowerFailureState";
 STATIC CHAR16 mResizeableBarsEnabledEfiVar[] = L"PCIeResizeableBarsEnabled";
 STATIC CHAR16 mOptionRomPolicyEfiVar[] = L"OptionRomPolicy";
 STATIC CHAR16 mEnableCameraEfiVar[] = L"EnableCamera";
+<<<<<<< HEAD
 STATIC CHAR16 mEnableWifiBtEfiVar[] = L"EnableWifiBt";
 STATIC CHAR16 mBatteryStartThresholdEfiVar[] = L"BatteryStartThreshold";
 STATIC CHAR16 mBatteryStopThresholdEfiVar[] = L"BatteryStopThreshold";
+=======
+STATIC CHAR16 mBatteryConfigEfiVar[] = L"BatteryConfig";
+>>>>>>> efa98d1a988d (Store both bat thresholds in single efivar)
 
 STATIC BOOLEAN   mUsbStackDefault = TRUE;
 STATIC BOOLEAN   mUsbMassStorageDefault = TRUE;
@@ -623,44 +627,24 @@ DasharoSystemFeaturesUiLibConstructor (
     ASSERT_EFI_ERROR (Status);
   }
 
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStartThreshold);
+  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig);
   Status = gRT->GetVariable (
-    mBatteryStartThresholdEfiVar,
+    mBatteryConfigEfiVar,
     &gDasharoSystemFeaturesGuid,
     NULL,
     &BufferSize,
-    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStartThreshold
+    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig
   );
 
   if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStartThreshold = mBatteryStartThresholdDefault;
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig.StartThreshold = mBatteryStartThresholdDefault;
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig.StopThreshold = mBatteryStopThresholdDefault;
     Status = gRT->SetVariable (
-        mBatteryStartThresholdEfiVar,
+        mBatteryConfigEfiVar,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStartThreshold),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStartThreshold
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStopThreshold);
-  Status = gRT->GetVariable (
-    mBatteryStopThresholdEfiVar,
-    &gDasharoSystemFeaturesGuid,
-    NULL,
-    &BufferSize,
-    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStopThreshold
-  );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStopThreshold = mBatteryStopThresholdDefault;
-    Status = gRT->SetVariable (
-        mBatteryStopThresholdEfiVar,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStopThreshold),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryStopThreshold
+        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig),
+        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig
         );
     ASSERT_EFI_ERROR (Status);
   }
@@ -1076,33 +1060,23 @@ DasharoSystemFeaturesRouteConfig (
     }
   }
 
-  if(DasharoFeaturesData.BatteryStartThreshold > DasharoFeaturesData.BatteryStopThreshold) {
+  if(DasharoFeaturesData.BatteryConfig.StartThreshold > DasharoFeaturesData.BatteryConfig.StopThreshold) {
     return EFI_INVALID_PARAMETER;
   }
 
-  if(Private->DasharoFeaturesData.BatteryStartThreshold != DasharoFeaturesData.BatteryStartThreshold) {
+  if (Private->DasharoFeaturesData.BatteryConfig.StartThreshold !=
+        DasharoFeaturesData.BatteryConfig.StartThreshold ||
+      Private->DasharoFeaturesData.BatteryConfig.StopThreshold !=
+        DasharoFeaturesData.BatteryConfig.StopThreshold) {
     Status = gRT->SetVariable (
-        mBatteryStartThresholdEfiVar,
+        mBatteryConfigEfiVar,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.BatteryStartThreshold),
-        &DasharoFeaturesData.BatteryStartThreshold
+        sizeof (DasharoFeaturesData.BatteryConfig),
+        &DasharoFeaturesData.BatteryConfig
         );
     if (EFI_ERROR (Status)) {
-        return Status;
-    }
-  }
-
-  if(Private->DasharoFeaturesData.BatteryStopThreshold != DasharoFeaturesData.BatteryStopThreshold) {
-    Status = gRT->SetVariable (
-        mBatteryStopThresholdEfiVar,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.BatteryStopThreshold),
-        &DasharoFeaturesData.BatteryStopThreshold
-        );
-    if (EFI_ERROR (Status)) {
-        return Status;
+      return Status;
     }
   }
 

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -1060,10 +1060,6 @@ DasharoSystemFeaturesRouteConfig (
     }
   }
 
-  if(DasharoFeaturesData.BatteryConfig.StartThreshold > DasharoFeaturesData.BatteryConfig.StopThreshold) {
-    return EFI_INVALID_PARAMETER;
-  }
-
   if (Private->DasharoFeaturesData.BatteryConfig.StartThreshold !=
         DasharoFeaturesData.BatteryConfig.StartThreshold ||
       Private->DasharoFeaturesData.BatteryConfig.StopThreshold !=

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -51,6 +51,7 @@ typedef struct {
   BOOLEAN            ShowPciMenu;
   BOOLEAN            PowerMenuShowFanCurve;
   BOOLEAN            PowerMenuShowSleepType;
+  BOOLEAN            PowerMenuShowBatteryThresholds;
   BOOLEAN            DasharoEnterprise;
   BOOLEAN            SecurityMenuShowIommu;
   BOOLEAN            PciMenuShowResizeableBars;
@@ -73,6 +74,8 @@ typedef struct {
   UINT8              OptionRomExecution;
   BOOLEAN            EnableCamera;
   BOOLEAN            EnableWifiBt;
+  UINT8              BatteryStartThreshold;
+  UINT8              BatteryStopThreshold;
 } DASHARO_FEATURES_DATA;
 
 #define ME_MODE_ENABLE        0

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -35,6 +35,11 @@ typedef struct {
   BOOLEAN IommuEnable;
   BOOLEAN IommuHandoff;
 } IOMMU_CONFIG;
+
+typedef struct {
+  UINT8  StartThreshold;
+  UINT8  StopThreshold;
+} BATTERY_CONFIG;
 #pragma pack(pop)
 
 #define FAN_CURVE_OPTION_SILENT 0
@@ -74,8 +79,7 @@ typedef struct {
   UINT8              OptionRomExecution;
   BOOLEAN            EnableCamera;
   BOOLEAN            EnableWifiBt;
-  UINT8              BatteryStartThreshold;
-  UINT8              BatteryStopThreshold;
+  BATTERY_CONFIG     BatteryConfig;
 } DASHARO_FEATURES_DATA;
 
 #define ME_MODE_ENABLE        0

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -126,10 +126,10 @@
 #string STR_WIFI_BT_ENABLE_PROMPT    #language en-US "Enable Wi-Fi + BT radios"
 #string STR_WIFI_BT_ENABLE_HELP      #language en-US "When not enabled, WiFi + Bluetooth card slot is disabled."
 
-#string STR_BATTERY_START_THRESHOLD_PROMPT    #language en-US "Battery charging start threshold"
+#string STR_BATTERY_START_THRESHOLD_PROMPT    #language en-US "Battery Start Charge Threshold"
 #string STR_BATTERY_START_THRESHOLD_HELP      #language en-US "The battery will start charging once the charge level drops below this value."
 
-#string STR_BATTERY_STOP_THRESHOLD_PROMPT    #language en-US "Battery charging stop threshold"
+#string STR_BATTERY_STOP_THRESHOLD_PROMPT    #language en-US "Battery Stop Charge Threshold"
 #string STR_BATTERY_STOP_THRESHOLD_HELP      #language en-US "The battery will stop charging once the charge level reaches this value."
 
 #string STR_BATTERY_THRESHOLD_RANGE_ERROR  #language en-US "The battery stop threshold must be greater than the start threshold!"

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -121,7 +121,15 @@
 #string STR_OPTION_ROM_ENABLE_VGA   #language en-US  "Enable OptionROM loading only on GPUs"
 
 #string STR_ENABLE_CAMERA_PROMPT    #language en-US "Enable Camera"
-#string STR_ENABLE_CAMERA_HELP    #language en-US "If this option is disabled, the power to the USB webcam is disconnected completely"
+#string STR_ENABLE_CAMERA_HELP      #language en-US "If this option is disabled, the power to the USB webcam is disconnected completely"
 
 #string STR_WIFI_BT_ENABLE_PROMPT    #language en-US "Enable Wi-Fi + BT radios"
 #string STR_WIFI_BT_ENABLE_HELP      #language en-US "When not enabled, WiFi + Bluetooth card slot is disabled."
+
+#string STR_BATTERY_START_THRESHOLD_PROMPT    #language en-US "Battery charging start threshold"
+#string STR_BATTERY_START_THRESHOLD_HELP      #language en-US "The battery will start charging once the charge level drops below this value."
+
+#string STR_BATTERY_STOP_THRESHOLD_PROMPT    #language en-US "Battery charging stop threshold"
+#string STR_BATTERY_STOP_THRESHOLD_HELP      #language en-US "The battery will stop charging once the charge level reaches this value."
+
+#string STR_BATTERY_THRESHOLD_RANGE_ERROR  #language en-US "The battery stop threshold must be greater than the start threshold!"

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -76,4 +76,5 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions
   gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPciMenuShowResizeableBars
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowBatteryThresholds
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -278,6 +278,33 @@ formset
          endoneof;
     endif;
 
+    suppressif ideqval FeaturesData.PowerMenuShowBatteryThresholds == 0;
+        numeric varid   = FeaturesData.BatteryStartThreshold,
+                prompt  = STRING_TOKEN(STR_BATTERY_START_THRESHOLD_PROMPT),
+                help    = STRING_TOKEN(STR_BATTERY_START_THRESHOLD_HELP),
+                flags   = RESET_REQUIRED | INTERACTIVE,
+                minimum = 0,
+                maximum = 100,
+                step    = 1,
+
+                nosubmitif prompt = STRING_TOKEN(STR_BATTERY_THRESHOLD_RANGE_ERROR),
+                    ideqid FeaturesData.BatteryStartThreshold > FeaturesData.BatteryStopThreshold
+                endif
+        endnumeric;
+        numeric varid   = FeaturesData.BatteryStopThreshold,
+                prompt  = STRING_TOKEN(STR_BATTERY_STOP_THRESHOLD_PROMPT),
+                help    = STRING_TOKEN(STR_BATTERY_STOP_THRESHOLD_HELP),
+                flags   = RESET_REQUIRED | INTERACTIVE,
+                minimum = 0,
+                maximum = 100,
+                step    = 1,
+
+                nosubmitif prompt = STRING_TOKEN(STR_BATTERY_THRESHOLD_RANGE_ERROR),
+                    ideqid FeaturesData.BatteryStartThreshold > FeaturesData.BatteryStopThreshold
+                endif
+        endnumeric;
+    endif;
+
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EXIT_STRING);

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -279,7 +279,7 @@ formset
     endif;
 
     suppressif ideqval FeaturesData.PowerMenuShowBatteryThresholds == 0;
-        numeric varid   = FeaturesData.BatteryStartThreshold,
+        numeric varid   = FeaturesData.BatteryConfig.StartThreshold,
                 prompt  = STRING_TOKEN(STR_BATTERY_START_THRESHOLD_PROMPT),
                 help    = STRING_TOKEN(STR_BATTERY_START_THRESHOLD_HELP),
                 flags   = RESET_REQUIRED | INTERACTIVE,
@@ -288,10 +288,10 @@ formset
                 step    = 1,
 
                 nosubmitif prompt = STRING_TOKEN(STR_BATTERY_THRESHOLD_RANGE_ERROR),
-                    ideqid FeaturesData.BatteryStartThreshold > FeaturesData.BatteryStopThreshold
+                    ideqid FeaturesData.BatteryConfig.StartThreshold > FeaturesData.BatteryConfig.StopThreshold
                 endif
         endnumeric;
-        numeric varid   = FeaturesData.BatteryStopThreshold,
+        numeric varid   = FeaturesData.BatteryConfig.StopThreshold,
                 prompt  = STRING_TOKEN(STR_BATTERY_STOP_THRESHOLD_PROMPT),
                 help    = STRING_TOKEN(STR_BATTERY_STOP_THRESHOLD_HELP),
                 flags   = RESET_REQUIRED | INTERACTIVE,
@@ -300,7 +300,7 @@ formset
                 step    = 1,
 
                 nosubmitif prompt = STRING_TOKEN(STR_BATTERY_THRESHOLD_RANGE_ERROR),
-                    ideqid FeaturesData.BatteryStartThreshold > FeaturesData.BatteryStopThreshold
+                    ideqid FeaturesData.BatteryConfig.StartThreshold > FeaturesData.BatteryConfig.StopThreshold
                 endif
         endnumeric;
     endif;


### PR DESCRIPTION
Add 2 options for battery charge start/stop thresholds. 2 separate checks prevent saving an invalid value (start thresh > stop thresh), one before submitting and one before saving to efi vars.

Upon attempting to save an invalid combination, a pop-up appears:

```
"The battery stop threshold must be greater than the start threshold!"
```

and the setting is not saved

@macpijan cc