### PR TITLE
Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c: warn abou…

### DIFF
--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -1095,6 +1095,9 @@ DasharoSystemFeaturesCallback (
             L"This will turn off all flash protection mechanisms",
             L"for the duration of next boot.",
             L"",
+            L"DTS will be started automatically through iPXE, please",
+            L"make sure Ethernet cable is connected before continuing.",
+            L"",
             L"Press ENTER to continue and reboot or ESC to cancel...",
             L"",
             NULL


### PR DESCRIPTION
…t network use

DTS will be automatically started after FUM is enabled. Inform user that Ethernet cable must be plugged in for seamless update process.