### PR TITLE
Add memory configuration menu with memory profile option

### DIFF
--- a/DasharoModulePkg.dec
+++ b/DasharoModulePkg.dec
@@ -56,6 +56,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPciMenu|FALSE|BOOLEAN|0x00000010
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPciMenuShowResizeableBars|FALSE|BOOLEAN|0x00000011
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowBatteryThresholds|FALSE|BOOLEAN|0x00000012
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowMemoryMenu|FALSE|BOOLEAN|0x000000013
 
 [PcdsFixedAtBuild,PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   ## Indicate whether the password is cleared.

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -222,6 +222,7 @@ DasharoSystemFeaturesUiLibConstructor (
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowChipsetMenu = PcdGetBool (PcdShowChipsetMenu);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowPowerMenu = PcdGetBool (PcdShowPowerMenu);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowPciMenu = PcdGetBool (PcdShowPciMenu);
+  mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowMemoryMenu = PcdGetBool (PcdShowMemoryMenu);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerMenuShowFanCurve = PcdGetBool (PcdPowerMenuShowFanCurve);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerMenuShowSleepType = PcdGetBool (PcdPowerMenuShowSleepType);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerMenuShowBatteryThresholds = PcdGetBool (PcdPowerMenuShowBatteryThresholds);

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause
 #define DASHARO_CHIPSET_CONFIGURATION_FORM_ID  0x1005
 #define DASHARO_POWER_CONFIGURATION_FORM_ID    0x1006
 #define DASHARO_PCI_CONFIGURATION_FORM_ID      0x1007
+#define DASHARO_MEMORY_CONFIGURATION_FORM_ID   0x1008
 
 #define DASHARO_FEATURES_DATA_VARSTORE_ID      0x0001
 
@@ -54,6 +55,7 @@ typedef struct {
   BOOLEAN            ShowChipsetMenu;
   BOOLEAN            ShowPowerMenu;
   BOOLEAN            ShowPciMenu;
+  BOOLEAN            ShowMemoryMenu;
   BOOLEAN            PowerMenuShowFanCurve;
   BOOLEAN            PowerMenuShowSleepType;
   BOOLEAN            PowerMenuShowBatteryThresholds;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -82,6 +82,7 @@ typedef struct {
   BOOLEAN            EnableCamera;
   BOOLEAN            EnableWifiBt;
   BATTERY_CONFIG     BatteryConfig;
+  UINT8              MemoryProfile;
 } DASHARO_FEATURES_DATA;
 
 #define ME_MODE_ENABLE        0
@@ -99,6 +100,12 @@ typedef struct {
 #define POWER_FAILURE_STATE_ON      1
 #define POWER_FAILURE_STATE_KEEP    2
 #define POWER_FAILURE_STATE_HIDDEN  0xff
+
+// Values aren't random, they match FSP_M_CONFIG::SpdProfileSelected
+#define MEMORY_PROFILE_JEDEC  0
+#define MEMORY_PROFILE_XMP1   2
+#define MEMORY_PROFILE_XMP2   3
+#define MEMORY_PROFILE_XMP3   4
 
 #define NETWORK_BOOT_QUESTION_ID          0x8000
 #define WATCHDOG_OPTIONS_QUESTION_ID      0x8001

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -136,3 +136,13 @@
 #string STR_BATTERY_STOP_THRESHOLD_HELP      #language en-US "The battery will stop charging once the charge level reaches this value."
 
 #string STR_BATTERY_THRESHOLD_RANGE_ERROR  #language en-US "The battery stop threshold must be greater than the start threshold!"
+
+#string STR_MEMORY_PROFILE_PROMPT   #language en-US  "Memory SPD Profile"
+#string STR_MEMORY_PROFILE_HELP     #language en-US  "This option selects memory profile applied to RAM modules.\n\n"
+                                                       "Selecting an XMP profile may result in unstable memory modules and even prevent system from booting.\n\n"
+                                                       "Changing this option causes memory retraining on the next boot which takes time to complete."
+
+#string STR_MEMORY_PROFILE_JEDEC   #language en-US  "JEDEC (safe non-overclocked default)"
+#string STR_MEMORY_PROFILE_XMP1    #language en-US  "XMP#1 (predefined extreme memory profile)"
+#string STR_MEMORY_PROFILE_XMP2    #language en-US  "XMP#2 (predefined extreme memory profile)"
+#string STR_MEMORY_PROFILE_XMP3    #language en-US  "XMP#3 (predefined extreme memory profile)"

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -35,6 +35,9 @@
 #string STR_DASHARO_PCI_CONFIGURATION_TITLE   #language en-US  "PCI/PCIe Configuration"
 #string STR_DASHARO_PCI_CONFIGURATION_HELP    #language en-US  "PCI/PCIe configuration options"
 
+#string STR_DASHARO_MEMORY_CONFIGURATION_TITLE   #language en-US  "Memory Configuration"
+#string STR_DASHARO_MEMORY_CONFIGURATION_HELP    #language en-US  "Memory-related options"
+
 #string STR_FUM_PROMPT   #language en-US  "> Enter Firmware Update Mode"
 #string STR_FUM_HELP     #language en-US  "Disables all firmware protections for the duration of next boot."
 

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -67,6 +67,7 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowChipsetMenu
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPowerMenu
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPciMenu
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowMemoryMenu
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowFanCurve
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowSleepType
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -64,6 +64,12 @@ formset
               help   = STRING_TOKEN(STR_DASHARO_PCI_CONFIGURATION_HELP);
     endif;
 
+    suppressif ideqval FeaturesData.ShowMemoryMenu == 0;
+         goto DASHARO_MEMORY_CONFIGURATION_FORM_ID,
+              prompt = STRING_TOKEN(STR_DASHARO_MEMORY_CONFIGURATION_TITLE),
+              help   = STRING_TOKEN(STR_DASHARO_MEMORY_CONFIGURATION_HELP);
+    endif;
+
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EXIT_STRING);
@@ -333,6 +339,16 @@ formset
              option text = STRING_TOKEN(STR_OPTION_ROM_ENABLE), value = OPTION_ROM_POLICY_ENABLE_ALL, flags = 0;
              option text = STRING_TOKEN(STR_OPTION_ROM_ENABLE_VGA), value = OPTION_ROM_POLICY_VGA_ONLY, flags = 0;
     endoneof;
+
+    subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
+    subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
+    subtitle text = STRING_TOKEN(STR_EXIT_STRING);
+  endform;
+
+  form formid = DASHARO_MEMORY_CONFIGURATION_FORM_ID,
+       title  = STRING_TOKEN(STR_DASHARO_MEMORY_CONFIGURATION_TITLE);
+
+    subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
 
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -350,6 +350,17 @@ formset
 
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
 
+    oneof varid = FeaturesData.MemoryProfile,
+             prompt = STRING_TOKEN(STR_MEMORY_PROFILE_PROMPT),
+             help   = STRING_TOKEN(STR_MEMORY_PROFILE_HELP),
+             flags  = RESET_REQUIRED,
+
+             option text = STRING_TOKEN(STR_MEMORY_PROFILE_JEDEC), value = MEMORY_PROFILE_JEDEC, flags = DEFAULT;
+             option text = STRING_TOKEN(STR_MEMORY_PROFILE_XMP1), value = MEMORY_PROFILE_XMP1, flags = 0;
+             option text = STRING_TOKEN(STR_MEMORY_PROFILE_XMP2), value = MEMORY_PROFILE_XMP2, flags = 0;
+             option text = STRING_TOKEN(STR_MEMORY_PROFILE_XMP3), value = MEMORY_PROFILE_XMP3, flags = 0;
+    endoneof;
+
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
     subtitle text = STRING_TOKEN(STR_EXIT_STRING);


### PR DESCRIPTION
Option labels are generic, need XMP2.0/XMP3.0 parser to be able to print actual speed/timings.  There seems to be nothing readily available for that (specs aren't available either), making displaying this information out of scope of this task.

Also noticed that EFI variables are not always stored on Z790-P.  It wasn't related exclusively to memory profile, so must not be related to these changes.  I don't think the same happened on Z690-A.  Thought maybe there is a bug in logic that stores configuration but doesn't look like it.