### PR TITLE
Add logic to set ME to default disabled and hide HAP

### DIFF
--- a/DasharoModulePkg.dec
+++ b/DasharoModulePkg.dec
@@ -62,6 +62,8 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirectionDefaultState|FALSE|BOOLEAN|0x000000015
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowWiFiBtOption|FALSE|BOOLEAN|0x000000016
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowCameraOption|FALSE|BOOLEAN|0x000000017
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeDefaultState|0|UINT8|0x000000018
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeHapAvailable|TRUE|BOOLEAN|0x000000019
 
 [PcdsFixedAtBuild,PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   ## Indicate whether the password is cleared.

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -42,7 +42,6 @@ STATIC BOOLEAN   mUsbStackDefault = TRUE;
 STATIC BOOLEAN   mUsbMassStorageDefault = TRUE;
 STATIC BOOLEAN   mLockBiosDefault = TRUE;
 STATIC BOOLEAN   mSmmBwpDefault = FALSE;
-STATIC UINT8     mMeModeDefault   = ME_MODE_ENABLE;
 STATIC BOOLEAN   mPs2ControllerDefault = TRUE;
 STATIC UINT8     mFanCurveOptionDefault = FAN_CURVE_OPTION_SILENT;
 STATIC UINT8     mIommuEnableDefault = FALSE;
@@ -235,6 +234,7 @@ DasharoSystemFeaturesUiLibConstructor (
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowSerialPortMenu = PcdGetBool (PcdShowSerialPortMenu);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SecurityMenuShowWiFiBt = PcdGetBool (PcdSecurityShowWiFiBtOption);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SecurityMenuShowCamera = PcdGetBool (PcdSecurityShowCameraOption);
+  mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeHapAvailable = PcdGetBool (PcdIntelMeHapAvailable);
 
   // Setup feature state
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios);
@@ -352,7 +352,7 @@ DasharoSystemFeaturesUiLibConstructor (
       );
 
   if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode = mMeModeDefault;
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode = FixedPcdGet8(PcdIntelMeDefaultState);
     Status = gRT->SetVariable (
         mMeModeEfiVar,
         &gDasharoSystemFeaturesGuid,
@@ -1253,6 +1253,14 @@ DasharoSystemFeaturesCallback (
             return EFI_INVALID_PARAMETER;
 
           Value->u8 = 98;
+          break;
+        }
+      case INTEL_ME_MODE_QUESTION_ID:
+        {
+          if (Value == NULL)
+            return EFI_INVALID_PARAMETER;
+
+          Value->u8 = FixedPcdGet8(PcdIntelMeDefaultState);
           break;
         }
       default:

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -66,6 +66,7 @@ typedef struct {
   BOOLEAN            PciMenuShowResizeableBars;
   BOOLEAN            SecurityMenuShowWiFiBt;
   BOOLEAN            SecurityMenuShowCamera;
+  BOOLEAN            MeHapAvailable;
   // Feature data
   BOOLEAN            LockBios;
   BOOLEAN            SmmBwp;
@@ -121,6 +122,7 @@ typedef struct {
 #define SERIAL_PORT_REDIR_QUESTION_ID        0x8006
 #define BATTERY_START_THRESHOLD_QUESTION_ID  0x8007
 #define BATTERY_STOP_THRESHOLD_QUESTION_ID   0x8008
+#define INTEL_ME_MODE_QUESTION_ID            0x8009
 
 extern EFI_GUID gDasharoSystemFeaturesGuid;
 

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -82,4 +82,6 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirectionDefaultState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowWiFiBtOption
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowCameraOption
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeDefaultState
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeHapAvailable
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -202,13 +202,16 @@ formset
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);
 
     oneof varid  = FeaturesData.MeMode,
+             questionid = INTEL_ME_MODE_QUESTION_ID,
              prompt = STRING_TOKEN(STR_ME_MODE_PROMPT),
              help   = STRING_TOKEN(STR_ME_MODE_HELP),
-             flags  = RESET_REQUIRED,
+             flags  = RESET_REQUIRED | INTERACTIVE,
 
-             option text = STRING_TOKEN(STR_ME_MODE_ENABLE), value = ME_MODE_ENABLE, flags = DEFAULT;
+             option text = STRING_TOKEN(STR_ME_MODE_ENABLE), value = ME_MODE_ENABLE, flags = 0;
              option text = STRING_TOKEN(STR_ME_MODE_DISABLE_HECI), value = ME_MODE_DISABLE_HECI, flags = 0;
+          suppressif ideqval FeaturesData.MeHapAvailable == 0;
              option text = STRING_TOKEN(STR_ME_MODE_DISABLE_HAP), value = ME_MODE_DISABLE_HAP, flags = 0;
+          endif;
     endoneof;
 
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);


### PR DESCRIPTION
Add new PCDs which control the visibility of HAP bit, in case the underlying coreboot code does not support HAP yet, and the default state of ME, if the platform should boot automatically in ME disabled mode. Protectli platform need to boot with ME disabled per customer policy.