### PR TITLE
DasharoBootPolicies: extract IOMMU setting to separate driver

### DIFF
--- a/DasharoBootPolicies/BootPolicies.c
+++ b/DasharoBootPolicies/BootPolicies.c
@@ -41,8 +41,6 @@ InitializeBootPolicies (
   EFI_STATUS  Status = EFI_SUCCESS;
   BOOLEAN *EfiVar;
   UINTN VarSize = sizeof(BOOLEAN);
-  IOMMU_CONFIG *IommuConfig;
-  UINT8 PcdVal = 0;
 
   gBS = SystemTable->BootServices;
   gRT = SystemTable->RuntimeServices;
@@ -149,36 +147,6 @@ InitializeBootPolicies (
       NULL
       );
     DEBUG ((EFI_D_INFO, "Boot Policy: Enabling PS2 Controller\n"));
-  }
-
-  VarSize = sizeof(*IommuConfig);
-  Status = GetVariable2 (
-           L"IommuConfig",
-           &gDasharoSystemFeaturesGuid,
-           (VOID **) &IommuConfig,
-           &VarSize
-           );
-
-  if ((Status == EFI_SUCCESS) && (VarSize == sizeof(*IommuConfig))){
-    PcdVal = PcdGet8(PcdVTdPolicyPropertyMask);
-    if (IommuConfig->IommuEnable){
-      PcdVal |= 0x01;
-      if (IommuConfig->IommuHandoff){
-        PcdVal |= 0x02;
-        DEBUG ((EFI_D_INFO, "Boot Policy: IOMMU will be kept enabled on ExitBootServices\n"));
-      }
-      else{
-        PcdVal &= (~0x02);
-        DEBUG ((EFI_D_INFO, "Boot Policy: IOMMU will be disabled on ExitBootServices\n"));
-      }
-      PcdSet8S(PcdVTdPolicyPropertyMask, PcdVal);
-    } else {
-      PcdSet8S(PcdVTdPolicyPropertyMask, PcdVal & (~0x03));
-      DEBUG ((EFI_D_INFO, "Boot Policy: DMA protection disabled\n"));
-    }
-  } else {
-    PcdSet8S(PcdVTdPolicyPropertyMask, PcdVal & (~0x03));
-    DEBUG ((EFI_D_INFO, "Boot Policy: DMA protection disabled\n"));
   }
 
   VarSize = sizeof(BOOLEAN);

--- a/DasharoBootPolicies/DasharoBootPolicies.inf
+++ b/DasharoBootPolicies/DasharoBootPolicies.inf
@@ -26,7 +26,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   DasharoModulePkg/DasharoModulePkg.dec
-  IntelSiliconPkg/IntelSiliconPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -52,8 +51,6 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirectionDefaultState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirection2DefaultState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdHave2ndUart
-  gIntelSiliconPkgTokenSpaceGuid.PcdVTdPolicyPropertyMask
-
 
 [Depex]
   gEfiVariableArchProtocolGuid

--- a/DasharoBootPoliciesVTd/BootPolicies.c
+++ b/DasharoBootPoliciesVTd/BootPolicies.c
@@ -1,0 +1,69 @@
+/*++
+Copyright (c)  1999  - 2014, Intel Corporation. All rights reserved
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+--*/
+
+/** @file
+**/
+
+#include <Library/PcdLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiLib.h>
+#include "Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h"
+
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+
+/**
+  Entry point for the Boot Policies Driver.
+  @param ImageHandle       Image handle of this driver.
+  @param SystemTable       Global system service table.
+  @retval EFI_SUCCESS      Initialization complete.
+**/
+EFI_STATUS
+EFIAPI
+InitializeBootPolicies (
+  IN EFI_HANDLE       ImageHandle,
+  IN EFI_SYSTEM_TABLE *SystemTable
+  )
+
+{
+  EFI_STATUS  Status = EFI_SUCCESS;
+  UINTN VarSize = sizeof(BOOLEAN);
+  IOMMU_CONFIG *IommuConfig;
+  UINT8 PcdVal = 0;
+
+  VarSize = sizeof(*IommuConfig);
+  Status = GetVariable2 (
+           L"IommuConfig",
+           &gDasharoSystemFeaturesGuid,
+           (VOID **) &IommuConfig,
+           &VarSize
+           );
+
+  if ((Status == EFI_SUCCESS) && (VarSize == sizeof(*IommuConfig))){
+    PcdVal = PcdGet8(PcdVTdPolicyPropertyMask);
+    if (IommuConfig->IommuEnable){
+      PcdVal |= 0x01;
+      if (IommuConfig->IommuHandoff){
+        PcdVal |= 0x02;
+        DEBUG ((EFI_D_INFO, "Boot Policy: IOMMU will be kept enabled on ExitBootServices\n"));
+      }
+      else{
+        PcdVal &= (~0x02);
+        DEBUG ((EFI_D_INFO, "Boot Policy: IOMMU will be disabled on ExitBootServices\n"));
+      }
+      PcdSet8S(PcdVTdPolicyPropertyMask, PcdVal);
+    } else {
+      PcdSet8S(PcdVTdPolicyPropertyMask, PcdVal & (~0x03));
+      DEBUG ((EFI_D_INFO, "Boot Policy: DMA protection disabled\n"));
+    }
+  } else {
+    PcdSet8S(PcdVTdPolicyPropertyMask, PcdVal & (~0x03));
+    DEBUG ((EFI_D_INFO, "Boot Policy: DMA protection disabled\n"));
+  }
+
+  return EFI_SUCCESS;
+}

--- a/DasharoBootPoliciesVTd/DasharoBootPoliciesVTd.inf
+++ b/DasharoBootPoliciesVTd/DasharoBootPoliciesVTd.inf
@@ -1,0 +1,47 @@
+#
+#
+# Copyright (c)  2024, 3mdeb Sp. z o.o.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DasharoBootPoliciesVTd
+  FILE_GUID                      = ca90493f-1a22-4d09-9c78-3894507eb646
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = InitializeBootPolicies
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources.common]
+  BootPolicies.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  DasharoModulePkg/DasharoModulePkg.dec
+  IntelSiliconPkg/IntelSiliconPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  PcdLib
+  UefiLib
+  PcdLib
+  UefiDriverEntryPoint
+  UefiRuntimeServicesTableLib
+
+[Guids]
+  gDasharoSystemFeaturesGuid           ### CONSUMES
+
+[Pcd]
+  gIntelSiliconPkgTokenSpaceGuid.PcdVTdPolicyPropertyMask
+
+[Depex]
+  gEfiVariableArchProtocolGuid


### PR DESCRIPTION
This is the only setting that requires edk2-platforms, and only for PcdVTdPolicyPropertyMask. As not all platforms support VTd, fetching edk2-platforms unconditionally isn't necessary.

This change creates the possibility to build Dasharo edk2 payload without edk2-platform.