### PR TITLE
Add API to measure Dasharo variables

### DIFF
--- a/DasharoBootPolicies/BootPolicies.c
+++ b/DasharoBootPolicies/BootPolicies.c
@@ -59,7 +59,7 @@ InitializeBootPolicies (
   mSerialRedirectionPolicy.SerialRedirectionEnabled = FALSE;
 
   Status = GetVariable2 (
-             L"NetworkBoot",
+             DASHARO_VAR_NETWORK_BOOT,
              &gDasharoSystemFeaturesGuid,
              (VOID **) &EfiVar,
              &VarSize
@@ -82,7 +82,7 @@ InitializeBootPolicies (
   }
 
   Status = GetVariable2 (
-             L"UsbDriverStack",
+             DASHARO_VAR_USB_STACK,
              &gDasharoSystemFeaturesGuid,
              (VOID **) &EfiVar,
              &VarSize
@@ -106,7 +106,7 @@ InitializeBootPolicies (
   }
 
   Status = GetVariable2 (
-             L"UsbMassStorage",
+             DASHARO_VAR_USB_MASS_STORAGE,
              &gDasharoSystemFeaturesGuid,
              (VOID **) &EfiVar,
              &VarSize
@@ -130,7 +130,7 @@ InitializeBootPolicies (
   }
 
   Status = GetVariable2 (
-             L"Ps2Controller",
+             DASHARO_VAR_PS2_CONTROLLER,
              &gDasharoSystemFeaturesGuid,
              (VOID **) &EfiVar,
              &VarSize
@@ -153,7 +153,7 @@ InitializeBootPolicies (
 
   VarSize = sizeof(*IommuConfig);
   Status = GetVariable2 (
-           L"IommuConfig",
+           DASHARO_VAR_IOMMU_CONFIG,
            &gDasharoSystemFeaturesGuid,
            (VOID **) &IommuConfig,
            &VarSize
@@ -183,7 +183,7 @@ InitializeBootPolicies (
 
   VarSize = sizeof(BOOLEAN);
   Status = GetVariable2 (
-             L"SerialRedirection",
+             DASHARO_VAR_SERIAL_REDIRECTION,
              &gDasharoSystemFeaturesGuid,
              (VOID **) &EfiVar,
              &VarSize
@@ -199,7 +199,7 @@ InitializeBootPolicies (
   if (FixedPcdGetBool (PcdHave2ndUart)) {
     VarSize = sizeof(BOOLEAN);
     Status = GetVariable2 (
-               L"SerialRedirection2",
+               DASHARO_VAR_SERIAL_REDIRECTION2,
                &gDasharoSystemFeaturesGuid,
                (VOID **) &EfiVar,
                &VarSize

--- a/DasharoBootPolicies/BootPolicies.c
+++ b/DasharoBootPolicies/BootPolicies.c
@@ -13,7 +13,7 @@ Copyright (c)  1999  - 2014, Intel Corporation. All rights reserved
 #include <Library/DebugLib.h>
 #include <Library/UefiLib.h>
 #include "BootPolicies.h"
-#include "Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h"
+#include <DasharoOptions.h>
 
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -41,7 +41,7 @@ InitializeBootPolicies (
   EFI_STATUS  Status = EFI_SUCCESS;
   BOOLEAN *EfiVar;
   UINTN VarSize = sizeof(BOOLEAN);
-  IOMMU_CONFIG *IommuConfig;
+  DASHARO_IOMMU_CONFIG *IommuConfig;
   UINT8 PcdVal = 0;
 
   gBS = SystemTable->BootServices;

--- a/Documentation/AddNewSetting.md
+++ b/Documentation/AddNewSetting.md
@@ -1,0 +1,196 @@
+This document is meant to outline the process of adding a new Dasharo setting.
+If something isn't covered, follow structure of the code used for some similar
+variable.  If possible, use alphabetic sorting of lists, although it's not a
+requirement.
+
+Examples below use a new setting called `NewSetting`/`NEW_SETTING` which should
+be replaced with an actual name of the setting.
+
+Basic variable implementation
+=============================
+
+EFI variables are managed by a dedicated library which is used by the UI code.
+It makes sense to start from here.
+
+Add variable name in `Include/DasharoOptions.h`
+-----------------------------------------------
+
+Add a new `#define DASHARO_VAR_*` near the top where other settings marked with
+`// Settings` are, for example:
+
+```
+#define DASHARO_VAR_NEW_SETTING           L"NewSetting"
+```
+
+This is an EFI variable name.  It should look roughly like the already existing
+ones.  The rest of the code should use the macro name after adding
+`#include <DasharoOptions.h>` and not the string literal which can have typos.
+
+Add default value in `Library/DasharoVariablesLib/DasharoVariablesLib.c`
+------------------------------------------------------------------------
+
+Add another `if`-statement to `GetVariableDefault()` setting default variable
+data, its size and additional EFI variable attributes if they are necessary.
+See below if variable data is not a primitive type.
+
+Updating `GetVariableDefault()` enables resetting and creation (see the next
+step) of the variable with the correct value.
+
+If the variable's data is a structure then additionally:
+1. Add a new `DASHARO_*` structure at the bottom of `Include/DasharoOptions.h`.
+2. Add the new structure to `VAR_DATA` in `Include/DasharoOptions.h` as well.
+
+Add variable creation in `Library/DasharoVariablesLib/DasharoVariablesLib.c`
+----------------------------------------------------------------------------
+
+By adding one more line to `mAllVariables` array there.
+
+Adding the setting to Dasharo System Features
+=============================================
+
+Before a variable can become visible in the UI, the code which implements the UI
+part needs to become aware of it.
+
+Add storage for new variable
+----------------------------
+
+Find `DASHARO_FEATURES_DATA` structure in
+`Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h` and add a new
+field after `// Feature data` like:
+
+```
+  BOOLEAN      NewSetting;
+```
+
+Add initialization to constructor of `DasharoSystemFeaturesUiLib`
+-----------------------------------------------------------------
+
+Update `DasharoSystemFeaturesUiLibConstructor()` in
+`Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c` by adding a new
+line like this:
+
+```
+  LOAD_VAR (DASHARO_VAR_NEW_SETTING, NewSetting);
+```
+
+`NewSetting` here is a field of `DASHARO_FEATURES_DATA` from the above step.
+
+Add saving of new value
+-----------------------
+
+`DasharoSystemFeaturesRouteConfig()` in
+`Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c` is responsible for
+writing changed values back into EFI variable storage.  Add a line like this to
+the function:
+
+```
+  STORE_VAR (DASHARO_VAR_NEW_SETTING, NewSetting);
+```
+
+Very similar to `LOAD_VAR`.
+
+Some variables can even be read-only, but add this line anyway for consistency.
+If no value change is detected, nothing gets written.
+
+Exposing the setting in Dasharo System Features UI
+==================================================
+
+A variable might exist without being visible to the user, it might be visible
+conditionally or unconditionally.  The last two cases require updating UI forms
+and tying them with the new code.
+
+Add UI strings to `Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni`
+---------------------------------------------------------------------------------------
+
+If your variable is called `DASHARO_VAR_NEW_SETTING`, add label and help
+prompt like the following:
+
+```
+#string STR_NEW_SETTING_PROMPT   #language en-US  "<text that appears in the form>"
+#string STR_NEW_SETTING_HELP     #language en-US  "<text that appears in help section of the form>"
+```
+
+The two IDs above (`STR_NEW_SETTING_PROMPT` and `STR_NEW_SETTING_HELP`) will be
+needed on modifying a form in the next step.
+
+Update `Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr` UI form
+--------------------------------------------------------------------------------
+
+The new setting will need to go to one of the sections surrounded by `form` and
+`endform`.  In some cases it might be necessary to add a new section.
+
+Most of the settings are booleans that get represented as checkboxes in which
+case the added lines would look like this:
+
+```
+        checkbox varid   = FeaturesData.NewSetting,
+                 prompt  = STRING_TOKEN(STR_NEW_SETTING_PROMPT),
+                 help    = STRING_TOKEN(STR_NEW_SETTING_HELP),
+                 flags   = RESET_REQUIRED,
+        endcheckbox;
+```
+
+Making a setting resettable
+===========================
+
+Not all UI elements described in VFR file can have their default specified there
+as well and that value might not be permanently fixed (i.e., configured at
+build-time or run-time).  Handling such a situation requires writing code which
+provides default value through a callback which in this case is called
+`DasharoSystemFeaturesCallback()` in
+`Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c` file.  For the
+callback to know which value to provide, it gets an integer value known as
+question ID which is specified in VFR file as well.
+
+Create question ID
+------------------
+
+Add a new definition at the bottom of
+`Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h` like this one:
+
+```
+#define NEW_SETTING_QUESTION_ID       0x8010
+```
+
+The integer value should be unique.
+
+Extend callback in `Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c`
+-------------------------------------------------------------------------------
+
+Handle a new case to `switch (QuestionId)` in `DasharoSystemFeaturesCallback()`
+like the following:
+
+```
+      case NEW_SETTING_QUESTION_ID:
+        Value->b = DasharoGetVariableDefault (DASHARO_VAR_NEW_SETTING).Boolean;
+        break;
+```
+
+Depending on the variable type you want to change `->b` and `.Boolean` parts.
+
+Update UI element in VFR file
+-----------------------------
+
+Find the element in question in
+`Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr` and add two
+fields to it (update flags if they already exist):
+
+```
+                  questionid = NEW_SETTING_QUESTION_ID,
+                  flags = RESET_REQUIRED | INTERACTIVE,
+```
+
+`RESET_REQUIRED` flag means that resetting settings will affect this particular
+one as well.
+
+`INTERACTIVE` flag means that the callback will be invoked for this element.
+**Adding `questionid` without setting `INTERACTIVE` flag won't have any useful
+effect.**
+
+Topics not covered
+==================
+
+Could be added in the future:
+
+* Adding a new submenu.
+* Controlling feature visibility via PCDs and hiding them in VFR.

--- a/Include/DasharoOptions.h
+++ b/Include/DasharoOptions.h
@@ -100,4 +100,14 @@ typedef struct {
 
 #pragma pack(pop)
 
+// Set of possible values of Dasharo variables.
+typedef union {
+  BOOLEAN  Boolean;
+  UINT8    Uint8;
+
+  DASHARO_WATCHDOG_CONFIG  Watchdog;
+  DASHARO_IOMMU_CONFIG     Iommu;
+  DASHARO_BATTERY_CONFIG   Battery;
+} DASHARO_VAR_DATA;
+
 #endif

--- a/Include/DasharoOptions.h
+++ b/Include/DasharoOptions.h
@@ -1,5 +1,5 @@
 /** @file
-Constants for options of Dasharo system features
+Declarations for options of Dasharo system features
 
 Copyright (c) 2023, 3mdeb Sp. z o.o. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -8,6 +8,48 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #ifndef _DASHARO_OPTIONS_H_
 #define _DASHARO_OPTIONS_H_
+
+//
+// Names of Dasharo-specific EFI variables in DasharoSystemFeaturesGuid
+// namespace.
+//
+
+// Settings
+#define DASHARO_VAR_BATTERY_CONFIG                L"BatteryConfig"
+#define DASHARO_VAR_BOOT_MANAGER_ENABLED          L"BootManagerEnabled"
+#define DASHARO_VAR_CPU_MAX_TEMPERATURE           L"CpuMaxTemperature"
+#define DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD  L"CpuMinThrottlingThreshold"
+#define DASHARO_VAR_CPU_THROTTLING_THRESHOLD      L"CpuThrottlingThreshold"
+#define DASHARO_VAR_ENABLE_CAMERA                 L"EnableCamera"
+#define DASHARO_VAR_ENABLE_WIFI_BT                L"EnableWifiBt"
+#define DASHARO_VAR_FAN_CURVE_OPTION              L"FanCurveOption"
+#define DASHARO_VAR_FIRMWARE_UPDATE_MODE          L"FirmwareUpdateMode"
+#define DASHARO_VAR_IOMMU_CONFIG                  L"IommuConfig"
+#define DASHARO_VAR_LOCK_BIOS                     L"LockBios"
+#define DASHARO_VAR_MEMORY_PROFILE                L"MemoryProfile"
+#define DASHARO_VAR_ME_MODE                       L"MeMode"
+#define DASHARO_VAR_NETWORK_BOOT                  L"NetworkBoot"
+#define DASHARO_VAR_OPTION_ROM_POLICY             L"OptionRomPolicy"
+#define DASHARO_VAR_POWER_FAILURE_STATE           L"PowerFailureState"
+#define DASHARO_VAR_PS2_CONTROLLER                L"Ps2Controller"
+#define DASHARO_VAR_RESIZEABLE_BARS_ENABLED       L"PCIeResizeableBarsEnabled"
+#define DASHARO_VAR_SERIAL_REDIRECTION            L"SerialRedirection"
+#define DASHARO_VAR_SERIAL_REDIRECTION2           L"SerialRedirection2"
+#define DASHARO_VAR_SLEEP_TYPE                    L"SleepType"
+#define DASHARO_VAR_SMM_BWP                       L"SmmBwp"
+#define DASHARO_VAR_USB_MASS_STORAGE              L"UsbMassStorage"
+#define DASHARO_VAR_USB_STACK                     L"UsbDriverStack"
+#define DASHARO_VAR_WATCHDOG                      L"WatchdogConfig"
+#define DASHARO_VAR_WATCHDOG_AVAILABLE            L"WatchdogAvailable"
+
+// Other
+#define DASHARO_VAR_SMBIOS_UUID  L"Type1UUID"
+#define DASHARO_VAR_SMBIOS_SN    L"Type2SN"
+
+//
+// Constants for some of the above EFI variables which typically have a value of
+// UINT8 type.
+//
 
 #define DASHARO_OPTION_ROM_POLICY_DISABLE_ALL  0
 #define DASHARO_OPTION_ROM_POLICY_ENABLE_ALL   1

--- a/Include/DasharoOptions.h
+++ b/Include/DasharoOptions.h
@@ -51,8 +51,53 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // UINT8 type.
 //
 
+#define DASHARO_FAN_CURVE_OPTION_SILENT        0
+#define DASHARO_FAN_CURVE_OPTION_PERFORMANCE   1
+
+#define DASHARO_ME_MODE_ENABLE                 0
+#define DASHARO_ME_MODE_DISABLE_HECI           1
+#define DASHARO_ME_MODE_DISABLE_HAP            2
+
 #define DASHARO_OPTION_ROM_POLICY_DISABLE_ALL  0
 #define DASHARO_OPTION_ROM_POLICY_ENABLE_ALL   1
 #define DASHARO_OPTION_ROM_POLICY_VGA_ONLY     2
+
+#define DASHARO_SLEEP_TYPE_S0IX                0
+#define DASHARO_SLEEP_TYPE_S3                  1
+
+#define DASHARO_POWER_FAILURE_STATE_OFF        0
+#define DASHARO_POWER_FAILURE_STATE_ON         1
+#define DASHARO_POWER_FAILURE_STATE_KEEP       2
+#define DASHARO_POWER_FAILURE_STATE_HIDDEN     0xff
+
+// The values aren't random, they match FSP_M_CONFIG::SpdProfileSelected
+#define DASHARO_MEMORY_PROFILE_JEDEC           0
+#define DASHARO_MEMORY_PROFILE_XMP1            2
+#define DASHARO_MEMORY_PROFILE_XMP2            3
+#define DASHARO_MEMORY_PROFILE_XMP3            4
+
+//
+// Structures describing format of some of the above EFI variables.  Must be
+// packed.
+//
+
+#pragma pack(push,1)
+
+typedef struct {
+  BOOLEAN  WatchdogEnable;
+  UINT16   WatchdogTimeout;
+} DASHARO_WATCHDOG_CONFIG;
+
+typedef struct {
+  BOOLEAN  IommuEnable;
+  BOOLEAN  IommuHandoff;
+} DASHARO_IOMMU_CONFIG;
+
+typedef struct {
+  UINT8  StartThreshold;
+  UINT8  StopThreshold;
+} DASHARO_BATTERY_CONFIG;
+
+#pragma pack(pop)
 
 #endif

--- a/Include/Library/DasharoVariablesLib.h
+++ b/Include/Library/DasharoVariablesLib.h
@@ -38,4 +38,18 @@ DasharoGetVariableAttributes (
   CHAR16  *VarName
   );
 
+/**
+  Measure EFI variables specific to Dasharo.
+
+  This function should be called before booting into an OS or a UEFI
+  application.
+
+  @retval RETURN_SUCCESS  Successfully measured all variables.
+**/
+EFI_STATUS
+EFIAPI
+DasharoMeasureVariables (
+  VOID
+  );
+
 #endif

--- a/Include/Library/DasharoVariablesLib.h
+++ b/Include/Library/DasharoVariablesLib.h
@@ -1,0 +1,28 @@
+/** @file
+  A library for providing services related to Dasharo-specific EFI variables.
+
+  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _DASHARO_VARIABLES_LIB_H_
+#define _DASHARO_VARIABLES_LIB_H_
+
+#include <Base.h>
+#include <DasharoOptions.h>
+
+/**
+  Query a default value for a specified variable.
+
+  @param VarName  Name of the variable.
+
+  @retval Default value which is all zeroes for an unknown variable name.
+**/
+DASHARO_VAR_DATA
+EFIAPI
+DasharoGetVariableDefault (
+  CHAR16  *VarName
+  );
+
+#endif

--- a/Include/Library/DasharoVariablesLib.h
+++ b/Include/Library/DasharoVariablesLib.h
@@ -25,4 +25,17 @@ DasharoGetVariableDefault (
   CHAR16  *VarName
   );
 
+/**
+  Query attributes of a specified variable.
+
+  @param VarName  Name of the variable.
+
+  @retval EFI variable attributes (the value is sensible for unknown ones).
+**/
+UINT32
+EFIAPI
+DasharoGetVariableAttributes (
+  CHAR16  *VarName
+  );
+
 #endif

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -207,255 +207,45 @@ DasharoSystemFeaturesUiLibConstructor (
                                                                       PcdGetBool (PcdPowerMenuShowBatteryThresholds) ||
                                                                       (FixedPcdGet8 (PcdDefaultPowerFailureState) != POWER_FAILURE_STATE_HIDDEN);
 
-  // Setup feature state
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_LOCK_BIOS,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios
-      );
-  ASSERT_EFI_ERROR (Status);
+#define LOAD_VAR(var, field) do {                                                   \
+    BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.field);  \
+    Status = gRT->GetVariable (                                                     \
+        (var),                                                                      \
+        &gDasharoSystemFeaturesGuid,                                                \
+        NULL,                                                                       \
+        &BufferSize,                                                                \
+        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.field                    \
+        );                                                                          \
+    ASSERT_EFI_ERROR (Status);                                                      \
+  } while (FALSE)
 
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_NETWORK_BOOT,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot
-      );
-  ASSERT_EFI_ERROR (Status);
+  LOAD_VAR (DASHARO_VAR_BATTERY_CONFIG, BatteryConfig);
+  LOAD_VAR (DASHARO_VAR_BOOT_MANAGER_ENABLED, BootManagerEnabled);
+  LOAD_VAR (DASHARO_VAR_CPU_MAX_TEMPERATURE, CpuMaxTemperature);
+  LOAD_VAR (DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD, CpuMinThrottlingThreshold);
+  LOAD_VAR (DASHARO_VAR_CPU_THROTTLING_THRESHOLD, CpuThrottlingThreshold);
+  LOAD_VAR (DASHARO_VAR_ENABLE_CAMERA, EnableCamera);
+  LOAD_VAR (DASHARO_VAR_ENABLE_WIFI_BT, EnableWifiBt);
+  LOAD_VAR (DASHARO_VAR_FAN_CURVE_OPTION, FanCurveOption);
+  LOAD_VAR (DASHARO_VAR_IOMMU_CONFIG, IommuConfig);
+  LOAD_VAR (DASHARO_VAR_LOCK_BIOS, LockBios);
+  LOAD_VAR (DASHARO_VAR_MEMORY_PROFILE, MemoryProfile);
+  LOAD_VAR (DASHARO_VAR_ME_MODE, MeMode);
+  LOAD_VAR (DASHARO_VAR_NETWORK_BOOT, NetworkBoot);
+  LOAD_VAR (DASHARO_VAR_OPTION_ROM_POLICY, OptionRomExecution);
+  LOAD_VAR (DASHARO_VAR_POWER_FAILURE_STATE, PowerFailureState);
+  LOAD_VAR (DASHARO_VAR_PS2_CONTROLLER, Ps2Controller);
+  LOAD_VAR (DASHARO_VAR_RESIZEABLE_BARS_ENABLED, ResizeableBarsEnabled);
+  LOAD_VAR (DASHARO_VAR_SERIAL_REDIRECTION, SerialPortRedirection);
+  LOAD_VAR (DASHARO_VAR_SERIAL_REDIRECTION2, SerialPort2Redirection);
+  LOAD_VAR (DASHARO_VAR_SLEEP_TYPE, SleepType);
+  LOAD_VAR (DASHARO_VAR_SMM_BWP, SmmBwp);
+  LOAD_VAR (DASHARO_VAR_USB_MASS_STORAGE, UsbMassStorage);
+  LOAD_VAR (DASHARO_VAR_USB_STACK, UsbStack);
+  LOAD_VAR (DASHARO_VAR_WATCHDOG, WatchdogConfig);
+  LOAD_VAR (DASHARO_VAR_WATCHDOG_AVAILABLE, WatchdogAvailable);
 
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_USB_STACK,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_USB_MASS_STORAGE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_SMM_BWP,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_ME_MODE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_OPTION_ROM_POLICY,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_PS2_CONTROLLER,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_WATCHDOG_AVAILABLE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_WATCHDOG,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled);
-  Status = gRT->GetVariable(
-      DASHARO_VAR_BOOT_MANAGER_ENABLED,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled
-      );
-  ASSERT_EFI_ERROR(Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_FAN_CURVE_OPTION,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption
-      );
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_IOMMU_CONFIG,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_SLEEP_TYPE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_POWER_FAILURE_STATE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera);
-  Status = gRT->GetVariable (
-    DASHARO_VAR_ENABLE_CAMERA,
-    &gDasharoSystemFeaturesGuid,
-    NULL,
-    &BufferSize,
-    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera
-  );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_ENABLE_WIFI_BT,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig);
-  Status = gRT->GetVariable (
-    DASHARO_VAR_BATTERY_CONFIG,
-    &gDasharoSystemFeaturesGuid,
-    NULL,
-    &BufferSize,
-    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig
-  );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_MEMORY_PROFILE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_SERIAL_REDIRECTION,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_SERIAL_REDIRECTION2,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection
-      );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold
-  );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_CPU_MAX_TEMPERATURE,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature
-  );
-  ASSERT_EFI_ERROR (Status);
-
-  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold);
-  Status = gRT->GetVariable (
-      DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD,
-      &gDasharoSystemFeaturesGuid,
-      NULL,
-      &BufferSize,
-      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold
-  );
-  ASSERT_EFI_ERROR (Status);
+#undef LOAD_VAR
 
   return EFI_SUCCESS;
 }

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -433,299 +433,52 @@ DasharoSystemFeaturesRouteConfig (
       );
   ASSERT_EFI_ERROR (Status);
 
-  if (Private->DasharoFeaturesData.LockBios != DasharoFeaturesData.LockBios) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_LOCK_BIOS,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.LockBios),
-        &DasharoFeaturesData.LockBios
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
+  // Can use CompareMem() on structures instead of a per-field comparison as
+  // long as they are packed.
+#define STORE_VAR(var, field) do {                               \
+    if (CompareMem (&Private->DasharoFeaturesData.field,         \
+                    &DasharoFeaturesData.field,                  \
+                    sizeof (DasharoFeaturesData.field)) != 0) {  \
+      Status = gRT->SetVariable (                                \
+          (var),                                                 \
+          &gDasharoSystemFeaturesGuid,                           \
+          DasharoGetVariableAttributes (var),                    \
+          sizeof (DasharoFeaturesData.field),                    \
+          &DasharoFeaturesData.field                             \
+          );                                                     \
+      if (EFI_ERROR (Status)) {                                  \
+        return Status;                                           \
+      }                                                          \
+    }                                                            \
+  } while (FALSE)
 
-  if (Private->DasharoFeaturesData.SmmBwp != DasharoFeaturesData.SmmBwp) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SMM_BWP,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.SmmBwp),
-        &DasharoFeaturesData.SmmBwp
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
+  STORE_VAR (DASHARO_VAR_BATTERY_CONFIG, BatteryConfig);
+  STORE_VAR (DASHARO_VAR_BOOT_MANAGER_ENABLED, BootManagerEnabled);
+  STORE_VAR (DASHARO_VAR_CPU_MAX_TEMPERATURE, CpuMaxTemperature);
+  STORE_VAR (DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD, CpuMinThrottlingThreshold);
+  STORE_VAR (DASHARO_VAR_CPU_THROTTLING_THRESHOLD, CpuThrottlingThreshold);
+  STORE_VAR (DASHARO_VAR_ENABLE_CAMERA, EnableCamera);
+  STORE_VAR (DASHARO_VAR_ENABLE_WIFI_BT, EnableWifiBt);
+  STORE_VAR (DASHARO_VAR_FAN_CURVE_OPTION, FanCurveOption);
+  STORE_VAR (DASHARO_VAR_IOMMU_CONFIG, IommuConfig);
+  STORE_VAR (DASHARO_VAR_LOCK_BIOS, LockBios);
+  STORE_VAR (DASHARO_VAR_MEMORY_PROFILE, MemoryProfile);
+  STORE_VAR (DASHARO_VAR_ME_MODE, MeMode);
+  STORE_VAR (DASHARO_VAR_NETWORK_BOOT, NetworkBoot);
+  STORE_VAR (DASHARO_VAR_OPTION_ROM_POLICY, OptionRomExecution);
+  STORE_VAR (DASHARO_VAR_POWER_FAILURE_STATE, PowerFailureState);
+  STORE_VAR (DASHARO_VAR_PS2_CONTROLLER, Ps2Controller);
+  STORE_VAR (DASHARO_VAR_RESIZEABLE_BARS_ENABLED, ResizeableBarsEnabled);
+  STORE_VAR (DASHARO_VAR_SERIAL_REDIRECTION, SerialPortRedirection);
+  STORE_VAR (DASHARO_VAR_SERIAL_REDIRECTION2, SerialPort2Redirection);
+  STORE_VAR (DASHARO_VAR_SLEEP_TYPE, SleepType);
+  STORE_VAR (DASHARO_VAR_SMM_BWP, SmmBwp);
+  STORE_VAR (DASHARO_VAR_USB_MASS_STORAGE, UsbMassStorage);
+  STORE_VAR (DASHARO_VAR_USB_STACK, UsbStack);
+  STORE_VAR (DASHARO_VAR_WATCHDOG, WatchdogConfig);
+  STORE_VAR (DASHARO_VAR_WATCHDOG_AVAILABLE, WatchdogAvailable);
 
-  if (Private->DasharoFeaturesData.NetworkBoot != DasharoFeaturesData.NetworkBoot) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_NETWORK_BOOT,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.NetworkBoot),
-        &DasharoFeaturesData.NetworkBoot
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.UsbStack != DasharoFeaturesData.UsbStack) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_USB_STACK,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.UsbStack),
-        &DasharoFeaturesData.UsbStack
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.UsbMassStorage != DasharoFeaturesData.UsbMassStorage) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_USB_MASS_STORAGE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.UsbMassStorage),
-        &DasharoFeaturesData.UsbMassStorage
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.MeMode != DasharoFeaturesData.MeMode) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_ME_MODE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.MeMode),
-        &DasharoFeaturesData.MeMode
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.Ps2Controller != DasharoFeaturesData.Ps2Controller) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_PS2_CONTROLLER,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.Ps2Controller),
-        &DasharoFeaturesData.Ps2Controller
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.FanCurveOption != DasharoFeaturesData.FanCurveOption) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_FAN_CURVE_OPTION,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.FanCurveOption),
-        &DasharoFeaturesData.FanCurveOption
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.BootManagerEnabled != DasharoFeaturesData.BootManagerEnabled) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_BOOT_MANAGER_ENABLED,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.BootManagerEnabled),
-        &DasharoFeaturesData.BootManagerEnabled
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.WatchdogConfig.WatchdogEnable !=
-        DasharoFeaturesData.WatchdogConfig.WatchdogEnable ||
-      Private->DasharoFeaturesData.WatchdogConfig.WatchdogTimeout !=
-        DasharoFeaturesData.WatchdogConfig.WatchdogTimeout) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_WATCHDOG,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.WatchdogConfig),
-        &DasharoFeaturesData.WatchdogConfig
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.IommuConfig.IommuEnable != DasharoFeaturesData.IommuConfig.IommuEnable ||
-      Private->DasharoFeaturesData.IommuConfig.IommuHandoff != DasharoFeaturesData.IommuConfig.IommuHandoff) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_IOMMU_CONFIG,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.IommuConfig),
-        &DasharoFeaturesData.IommuConfig
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.SleepType != DasharoFeaturesData.SleepType) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SLEEP_TYPE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.SleepType),
-        &DasharoFeaturesData.SleepType
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.PowerFailureState != DasharoFeaturesData.PowerFailureState) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_POWER_FAILURE_STATE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.PowerFailureState),
-        &DasharoFeaturesData.PowerFailureState
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.EnableWifiBt != DasharoFeaturesData.EnableWifiBt) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_ENABLE_WIFI_BT,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.EnableWifiBt),
-        &DasharoFeaturesData.EnableWifiBt
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.ResizeableBarsEnabled != DasharoFeaturesData.ResizeableBarsEnabled) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.ResizeableBarsEnabled),
-        &DasharoFeaturesData.ResizeableBarsEnabled
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.OptionRomExecution != DasharoFeaturesData.OptionRomExecution) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_OPTION_ROM_POLICY,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.OptionRomExecution),
-        &DasharoFeaturesData.OptionRomExecution
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if(Private->DasharoFeaturesData.EnableCamera != DasharoFeaturesData.EnableCamera) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_ENABLE_CAMERA,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.EnableCamera),
-        &DasharoFeaturesData.EnableCamera
-        );
-    if (EFI_ERROR (Status)) {
-        return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.BatteryConfig.StartThreshold !=
-        DasharoFeaturesData.BatteryConfig.StartThreshold ||
-      Private->DasharoFeaturesData.BatteryConfig.StopThreshold !=
-        DasharoFeaturesData.BatteryConfig.StopThreshold) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_BATTERY_CONFIG,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.BatteryConfig),
-        &DasharoFeaturesData.BatteryConfig
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.MemoryProfile != DasharoFeaturesData.MemoryProfile) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_MEMORY_PROFILE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.MemoryProfile),
-        &DasharoFeaturesData.MemoryProfile
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.SerialPortRedirection != DasharoFeaturesData.SerialPortRedirection) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SERIAL_REDIRECTION,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.SerialPortRedirection),
-        &DasharoFeaturesData.SerialPortRedirection
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.SerialPort2Redirection != DasharoFeaturesData.SerialPort2Redirection) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SERIAL_REDIRECTION2,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.SerialPort2Redirection),
-        &DasharoFeaturesData.SerialPort2Redirection
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
-  if (Private->DasharoFeaturesData.CpuThrottlingThreshold !=
-        DasharoFeaturesData.CpuThrottlingThreshold) {
-    Status = gRT->SetVariable (
-        DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (DasharoFeaturesData.CpuThrottlingThreshold),
-        &DasharoFeaturesData.CpuThrottlingThreshold
-        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
+#undef STORE_VAR
 
   Private->DasharoFeaturesData = DasharoFeaturesData;
   return EFI_SUCCESS;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -15,23 +15,6 @@ SPDX-License-Identifier: BSD-2-Clause
 // Feature state
 STATIC CHAR16 mVarStoreName[] = L"FeaturesData";
 
-STATIC BOOLEAN   mUsbStackDefault = TRUE;
-STATIC BOOLEAN   mUsbMassStorageDefault = TRUE;
-STATIC BOOLEAN   mLockBiosDefault = TRUE;
-STATIC BOOLEAN   mSmmBwpDefault = FALSE;
-STATIC BOOLEAN   mPs2ControllerDefault = TRUE;
-STATIC UINT8     mFanCurveOptionDefault = FAN_CURVE_OPTION_SILENT;
-STATIC UINT8     mIommuEnableDefault = FALSE;
-STATIC UINT8     mIommuHandoffDefault = FALSE;
-STATIC BOOLEAN   mBootManagerEnabledDefault = TRUE;
-STATIC UINT8     mResizeableBarsEnabledDefault = FALSE;
-STATIC BOOLEAN   mEnableCameraDefault = TRUE;
-STATIC BOOLEAN   mEnableWifiBtDefault = TRUE;
-STATIC UINT8     mBatteryStartThresholdDefault = 95;
-STATIC UINT8     mBatteryStopThresholdDefault = 98;
-STATIC UINT8     mMemoryProfileDefault = MEMORY_PROFILE_JEDEC;
-STATIC UINT8     mCpuThrottlingThresholdDefault = 80;
-
 STATIC DASHARO_SYSTEM_FEATURES_PRIVATE_DATA  mDasharoSystemFeaturesPrivate = {
   DASHARO_SYSTEM_FEATURES_PRIVATE_DATA_SIGNATURE,
   NULL,
@@ -129,23 +112,6 @@ LocateAcpiTableBySignature (
   /// If we found the table, there will be no error.
   ///
   return Status;
-}
-
-/**
-  This function will be called only if the Watchdog variable is not present.
-  It will populate the initial state based on what coreboot has programmed.
-  If watchdog was not enabled on first boot, it means it was not enabled,
-  and watchdog options should be hidden (WatchdogAvailable == FALSE);
-**/
-VOID
-EFIAPI
-GetDefaultWatchdogConfig (
-  IN OUT  DASHARO_FEATURES_DATA       *FeaturesData
-  )
-{
-    FeaturesData->WatchdogAvailable = PcdGetBool (PcdShowOcWdtOptions);
-    FeaturesData->WatchdogConfig.WatchdogEnable = PcdGetBool (PcdOcWdtEnableDefault);
-    FeaturesData->WatchdogConfig.WatchdogTimeout = FixedPcdGet16 (PcdOcWdtTimeoutDefault);
 }
 
 /**
@@ -250,18 +216,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios = mLockBiosDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_LOCK_BIOS,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot);
   Status = gRT->GetVariable (
@@ -271,18 +226,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot = PcdGetBool (PcdDefaultNetworkBootEnable);
-    Status = gRT->SetVariable (
-        DASHARO_VAR_NETWORK_BOOT,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack);
   Status = gRT->GetVariable (
@@ -292,18 +236,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack = mUsbStackDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_USB_STACK,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage);
   Status = gRT->GetVariable (
@@ -313,18 +246,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage = mUsbMassStorageDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_USB_MASS_STORAGE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp);
   Status = gRT->GetVariable (
@@ -334,18 +256,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp = mSmmBwpDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SMM_BWP,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode);
   Status = gRT->GetVariable (
@@ -355,18 +266,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode = FixedPcdGet8(PcdIntelMeDefaultState);
-    Status = gRT->SetVariable (
-        DASHARO_VAR_ME_MODE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution);
   Status = gRT->GetVariable (
@@ -376,20 +276,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution = PcdGetBool (PcdLoadOptionRoms)
-        ? OPTION_ROM_POLICY_ENABLE_ALL
-        : OPTION_ROM_POLICY_DISABLE_ALL;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_OPTION_ROM_POLICY,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller);
   Status = gRT->GetVariable (
@@ -399,18 +286,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller = mPs2ControllerDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_PS2_CONTROLLER,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable);
   Status = gRT->GetVariable (
@@ -420,48 +296,17 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable
       );
+  ASSERT_EFI_ERROR (Status);
 
-  if (Status == EFI_NOT_FOUND) {
-    GetDefaultWatchdogConfig(&mDasharoSystemFeaturesPrivate.DasharoFeaturesData);
-
-    Status = gRT->SetVariable (
-        DASHARO_VAR_WATCHDOG,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig
-        );
-    ASSERT_EFI_ERROR (Status);
-
-    Status = gRT->SetVariable (
-        DASHARO_VAR_WATCHDOG_AVAILABLE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable
-        );
-    ASSERT_EFI_ERROR (Status);
-  } else {
-    BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig);
-    Status = gRT->GetVariable (
-        DASHARO_VAR_WATCHDOG,
-        &gDasharoSystemFeaturesGuid,
-        NULL,
-        &BufferSize,
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig
-        );
-
-    if (Status == EFI_NOT_FOUND) {
-      Status = gRT->SetVariable (
-          DASHARO_VAR_WATCHDOG,
-          &gDasharoSystemFeaturesGuid,
-          EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-          sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig),
-          &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig
-          );
-      ASSERT_EFI_ERROR (Status);
-    }
-  }
+  BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig);
+  Status = gRT->GetVariable (
+      DASHARO_VAR_WATCHDOG,
+      &gDasharoSystemFeaturesGuid,
+      NULL,
+      &BufferSize,
+      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig
+      );
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled);
   Status = gRT->GetVariable(
@@ -469,20 +314,9 @@ DasharoSystemFeaturesUiLibConstructor (
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
-	    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled
+      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled
       );
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled = mBootManagerEnabledDefault;
-    Status = gRT->SetVariable(
-	    DASHARO_VAR_BOOT_MANAGER_ENABLED,
-      &gDasharoSystemFeaturesGuid,
-	    EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-	    sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled),
-	    &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled
-      );
-
-    ASSERT_EFI_ERROR(Status);
-  }
+  ASSERT_EFI_ERROR(Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption);
   Status = gRT->GetVariable (
@@ -493,18 +327,6 @@ DasharoSystemFeaturesUiLibConstructor (
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption
       );
 
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption = mFanCurveOptionDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_FAN_CURVE_OPTION,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
-
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig);
   Status = gRT->GetVariable (
       DASHARO_VAR_IOMMU_CONFIG,
@@ -513,19 +335,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig.IommuEnable = mIommuEnableDefault;
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig.IommuHandoff = mIommuHandoffDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_IOMMU_CONFIG,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType);
   Status = gRT->GetVariable (
@@ -535,20 +345,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType = PcdGetBool (PcdSleepTypeDefaultS3)
-                                                                ? SLEEP_TYPE_S3
-                                                                : SLEEP_TYPE_S0IX;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SLEEP_TYPE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState);
   Status = gRT->GetVariable (
@@ -558,20 +355,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState =
-        FixedPcdGet8 (PcdDefaultPowerFailureState);
-
-    Status = gRT->SetVariable (
-        DASHARO_VAR_POWER_FAILURE_STATE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled);
   Status = gRT->GetVariable (
@@ -581,18 +365,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled = mResizeableBarsEnabledDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera);
   Status = gRT->GetVariable (
@@ -602,18 +375,7 @@ DasharoSystemFeaturesUiLibConstructor (
     &BufferSize,
     &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera
   );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera = mEnableCameraDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_ENABLE_CAMERA,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt);
   Status = gRT->GetVariable (
@@ -623,18 +385,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt = mEnableWifiBtDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_ENABLE_WIFI_BT,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig);
   Status = gRT->GetVariable (
@@ -644,19 +395,7 @@ DasharoSystemFeaturesUiLibConstructor (
     &BufferSize,
     &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig
   );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig.StartThreshold = mBatteryStartThresholdDefault;
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig.StopThreshold = mBatteryStopThresholdDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_BATTERY_CONFIG,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile);
   Status = gRT->GetVariable (
@@ -666,18 +405,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile = mMemoryProfileDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_MEMORY_PROFILE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection);
   Status = gRT->GetVariable (
@@ -687,19 +415,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection = PcdGetBool (PcdSerialRedirectionDefaultState);
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SERIAL_REDIRECTION,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
-
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection);
   Status = gRT->GetVariable (
@@ -709,20 +425,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection
       );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection = PcdGetBool(PcdHave2ndUart) ?
-                                                                                PcdGetBool (PcdSerialRedirection2DefaultState) :
-                                                                                FALSE;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_SERIAL_REDIRECTION2,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold);
   Status = gRT->GetVariable (
@@ -732,18 +435,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold
   );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold = mCpuThrottlingThresholdDefault;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature);
   Status = gRT->GetVariable (
@@ -753,18 +445,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature
   );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature = FixedPcdGet8(PcdCpuMaxTemperature);
-    Status = gRT->SetVariable (
-        DASHARO_VAR_CPU_MAX_TEMPERATURE,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold);
   Status = gRT->GetVariable (
@@ -774,18 +455,7 @@ DasharoSystemFeaturesUiLibConstructor (
       &BufferSize,
       &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold
   );
-
-  if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold = FixedPcdGet8(PcdCpuMaxTemperature) - 63;
-    Status = gRT->SetVariable (
-        DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD,
-        &gDasharoSystemFeaturesGuid,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
-        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold),
-        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold
-        );
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;
 }

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -8,6 +8,8 @@ SPDX-License-Identifier: BSD-2-Clause
 
 #include "DasharoSystemFeatures.h"
 
+#include <Library/DasharoVariablesLib.h>
+
 #define PCH_OC_WDT_CTL				0x54
 #define   PCH_OC_WDT_CTL_EN			BIT14
 #define   PCH_OC_WDT_CTL_TOV_MASK		0x3FF
@@ -185,8 +187,6 @@ DasharoSystemFeaturesUiLibConstructor (
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowPs2Option = PcdGetBool (PcdShowPs2Option);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Have2ndUart = PcdGetBool (PcdHave2ndUart);
   mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowCpuThrottlingThreshold= PcdGetBool (PcdShowCpuThrottlingThreshold);
-  mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature = FixedPcdGet8(PcdCpuMaxTemperature);
-  mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold = FixedPcdGet8(PcdCpuMaxTemperature) - 63;
 
   // Ensure at least one option is visible in given menu (if enabled), otherwise hide it
   if (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ShowSecurityMenu)
@@ -769,103 +769,43 @@ DasharoSystemFeaturesCallback (
   case EFI_BROWSER_ACTION_DEFAULT_STANDARD:
   case EFI_BROWSER_ACTION_DEFAULT_MANUFACTURING:
     {
+      if (Value == NULL)
+        return EFI_INVALID_PARAMETER;
+
       switch (QuestionId) {
       case NETWORK_BOOT_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->b = PcdGetBool (PcdDefaultNetworkBootEnable);
-          break;
-        }
+        Value->b = DasharoGetVariableDefault (DASHARO_VAR_NETWORK_BOOT).Boolean;
+        break;
       case WATCHDOG_ENABLE_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->b = PcdGetBool (PcdOcWdtEnableDefault);
-          break;
-        }
+        Value->b = DasharoGetVariableDefault (DASHARO_VAR_WATCHDOG).Watchdog.WatchdogEnable;
+        break;
       case WATCHDOG_TIMEOUT_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->u16 = FixedPcdGet16 (PcdOcWdtTimeoutDefault);
-          break;
-        }
+        Value->u16 = DasharoGetVariableDefault (DASHARO_VAR_WATCHDOG).Watchdog.WatchdogTimeout;
+        break;
       case POWER_FAILURE_STATE_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->u8 = FixedPcdGet8 (PcdDefaultPowerFailureState);
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_POWER_FAILURE_STATE).Boolean;
+        break;
       case OPTION_ROM_STATE_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->u8 = PcdGetBool (PcdLoadOptionRoms) ? OPTION_ROM_POLICY_ENABLE_ALL
-                                                          : OPTION_ROM_POLICY_DISABLE_ALL;
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_OPTION_ROM_POLICY).Uint8;
+        break;
       case SERIAL_PORT_REDIR_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->b = PcdGetBool (PcdSerialRedirectionDefaultState);
-          break;
-        }
-        case SERIAL_PORT2_REDIR_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          if (PcdGetBool (PcdHave2ndUart))
-            Value->b = PcdGetBool (PcdSerialRedirection2DefaultState);
-          else
-            Value->b = FALSE;
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_SERIAL_REDIRECTION).Boolean;
+        break;
+      case SERIAL_PORT2_REDIR_QUESTION_ID:
+        Value->b = DasharoGetVariableDefault (DASHARO_VAR_SERIAL_REDIRECTION2).Boolean;
+        break;
       case BATTERY_START_THRESHOLD_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->u8 = 95;
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_BATTERY_CONFIG).Battery.StartThreshold;
+        break;
       case BATTERY_STOP_THRESHOLD_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->u8 = 98;
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_BATTERY_CONFIG).Battery.StopThreshold;
+        break;
       case INTEL_ME_MODE_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          Value->u8 = FixedPcdGet8(PcdIntelMeDefaultState);
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_ME_MODE).Uint8;
+        break;
       case SLEEP_TYPE_QUESTION_ID:
-        {
-          if (Value == NULL)
-            return EFI_INVALID_PARAMETER;
-
-          if (PcdGetBool (PcdSleepTypeDefaultS3))
-            Value->u8 = SLEEP_TYPE_S3;
-          else
-            Value->u8 = SLEEP_TYPE_S0IX;
-
-          break;
-        }
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_SLEEP_TYPE).Uint8;
+        break;
       default:
         Status = EFI_UNSUPPORTED;
         break;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -15,31 +15,6 @@ SPDX-License-Identifier: BSD-2-Clause
 // Feature state
 STATIC CHAR16 mVarStoreName[] = L"FeaturesData";
 
-STATIC CHAR16 mLockBiosEfiVar[] = L"LockBios";
-STATIC CHAR16 mSmmBwpEfiVar[] = L"SmmBwp";
-STATIC CHAR16 mMeModeEfiVar[] = L"MeMode";
-STATIC CHAR16 mNetworkBootEfiVar[] = L"NetworkBoot";
-STATIC CHAR16 mUsbStackEfiVar[] = L"UsbDriverStack";
-STATIC CHAR16 mUsbMassStorageEfiVar[] = L"UsbMassStorage";
-STATIC CHAR16 mBootManagerEnabledEfiVar[] = L"BootManagerEnabled";
-STATIC CHAR16 mPs2ControllerEfiVar[] = L"Ps2Controller";
-STATIC CHAR16 mWatchdogEfiVar[] = L"WatchdogConfig";
-STATIC CHAR16 mWatchdogAvailableEfiVar[] = L"WatchdogAvailable";
-STATIC CHAR16 mFanCurveOptionEfiVar[] = L"FanCurveOption";
-STATIC CHAR16 mIommuConfigEfiVar[] = L"IommuConfig";
-STATIC CHAR16 mSleepTypeEfiVar[] = L"SleepType";
-STATIC CHAR16 mFirmwareUpdateModeEfiVar[] = L"FirmwareUpdateMode";
-STATIC CHAR16 mPowerFailureStateEfiVar[] = L"PowerFailureState";
-STATIC CHAR16 mResizeableBarsEnabledEfiVar[] = L"PCIeResizeableBarsEnabled";
-STATIC CHAR16 mOptionRomPolicyEfiVar[] = L"OptionRomPolicy";
-STATIC CHAR16 mEnableCameraEfiVar[] = L"EnableCamera";
-STATIC CHAR16 mEnableWifiBtEfiVar[] = L"EnableWifiBt";
-STATIC CHAR16 mBatteryConfigEfiVar[] = L"BatteryConfig";
-STATIC CHAR16 mMemoryProfileEfiVar[] = L"MemoryProfile";
-STATIC CHAR16 mSerialRedirectionEfiVar[] = L"SerialRedirection";
-STATIC CHAR16 mSerialRedirection2EfiVar[] = L"SerialRedirection2";
-STATIC CHAR16 mCpuThrottlingThresholdEfiVar[] = L"CpuThrottlingThreshold";
-
 STATIC BOOLEAN   mUsbStackDefault = TRUE;
 STATIC BOOLEAN   mUsbMassStorageDefault = TRUE;
 STATIC BOOLEAN   mLockBiosDefault = TRUE;
@@ -270,7 +245,7 @@ DasharoSystemFeaturesUiLibConstructor (
   // Setup feature state
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios);
   Status = gRT->GetVariable (
-      mLockBiosEfiVar,
+      DASHARO_VAR_LOCK_BIOS,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -280,7 +255,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios = mLockBiosDefault;
     Status = gRT->SetVariable (
-        mLockBiosEfiVar,
+        DASHARO_VAR_LOCK_BIOS,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.LockBios),
@@ -291,7 +266,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot);
   Status = gRT->GetVariable (
-      mNetworkBootEfiVar,
+      DASHARO_VAR_NETWORK_BOOT,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -301,7 +276,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot = PcdGetBool (PcdDefaultNetworkBootEnable);
     Status = gRT->SetVariable (
-        mNetworkBootEfiVar,
+        DASHARO_VAR_NETWORK_BOOT,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.NetworkBoot),
@@ -312,7 +287,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack);
   Status = gRT->GetVariable (
-      mUsbStackEfiVar,
+      DASHARO_VAR_USB_STACK,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -322,7 +297,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack = mUsbStackDefault;
     Status = gRT->SetVariable (
-        mUsbStackEfiVar,
+        DASHARO_VAR_USB_STACK,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbStack),
@@ -333,7 +308,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage);
   Status = gRT->GetVariable (
-      mUsbMassStorageEfiVar,
+      DASHARO_VAR_USB_MASS_STORAGE,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -343,7 +318,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage = mUsbMassStorageDefault;
     Status = gRT->SetVariable (
-        mUsbMassStorageEfiVar,
+        DASHARO_VAR_USB_MASS_STORAGE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.UsbMassStorage),
@@ -354,7 +329,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp);
   Status = gRT->GetVariable (
-      mSmmBwpEfiVar,
+      DASHARO_VAR_SMM_BWP,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -364,7 +339,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp = mSmmBwpDefault;
     Status = gRT->SetVariable (
-        mSmmBwpEfiVar,
+        DASHARO_VAR_SMM_BWP,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SmmBwp),
@@ -375,7 +350,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode);
   Status = gRT->GetVariable (
-      mMeModeEfiVar,
+      DASHARO_VAR_ME_MODE,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -385,7 +360,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode = FixedPcdGet8(PcdIntelMeDefaultState);
     Status = gRT->SetVariable (
-        mMeModeEfiVar,
+        DASHARO_VAR_ME_MODE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MeMode),
@@ -396,7 +371,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution);
   Status = gRT->GetVariable (
-      mOptionRomPolicyEfiVar,
+      DASHARO_VAR_OPTION_ROM_POLICY,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -408,7 +383,7 @@ DasharoSystemFeaturesUiLibConstructor (
         ? OPTION_ROM_POLICY_ENABLE_ALL
         : OPTION_ROM_POLICY_DISABLE_ALL;
     Status = gRT->SetVariable (
-        mOptionRomPolicyEfiVar,
+        DASHARO_VAR_OPTION_ROM_POLICY,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.OptionRomExecution),
@@ -419,7 +394,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller);
   Status = gRT->GetVariable (
-      mPs2ControllerEfiVar,
+      DASHARO_VAR_PS2_CONTROLLER,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -429,7 +404,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller = mPs2ControllerDefault;
     Status = gRT->SetVariable (
-        mPs2ControllerEfiVar,
+        DASHARO_VAR_PS2_CONTROLLER,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.Ps2Controller),
@@ -440,7 +415,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable);
   Status = gRT->GetVariable (
-      mWatchdogAvailableEfiVar,
+      DASHARO_VAR_WATCHDOG_AVAILABLE,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -451,7 +426,7 @@ DasharoSystemFeaturesUiLibConstructor (
     GetDefaultWatchdogConfig(&mDasharoSystemFeaturesPrivate.DasharoFeaturesData);
 
     Status = gRT->SetVariable (
-        mWatchdogEfiVar,
+        DASHARO_VAR_WATCHDOG,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig),
@@ -460,7 +435,7 @@ DasharoSystemFeaturesUiLibConstructor (
     ASSERT_EFI_ERROR (Status);
 
     Status = gRT->SetVariable (
-        mWatchdogAvailableEfiVar,
+        DASHARO_VAR_WATCHDOG_AVAILABLE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogAvailable),
@@ -470,7 +445,7 @@ DasharoSystemFeaturesUiLibConstructor (
   } else {
     BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig);
     Status = gRT->GetVariable (
-        mWatchdogEfiVar,
+        DASHARO_VAR_WATCHDOG,
         &gDasharoSystemFeaturesGuid,
         NULL,
         &BufferSize,
@@ -479,7 +454,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
     if (Status == EFI_NOT_FOUND) {
       Status = gRT->SetVariable (
-          mWatchdogEfiVar,
+          DASHARO_VAR_WATCHDOG,
           &gDasharoSystemFeaturesGuid,
           EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
           sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.WatchdogConfig),
@@ -491,7 +466,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled);
   Status = gRT->GetVariable(
-      mBootManagerEnabledEfiVar,
+      DASHARO_VAR_BOOT_MANAGER_ENABLED,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -500,7 +475,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled = mBootManagerEnabledDefault;
     Status = gRT->SetVariable(
-	    mBootManagerEnabledEfiVar,
+	    DASHARO_VAR_BOOT_MANAGER_ENABLED,
       &gDasharoSystemFeaturesGuid,
 	    EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
 	    sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BootManagerEnabled),
@@ -512,7 +487,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption);
   Status = gRT->GetVariable (
-      mFanCurveOptionEfiVar,
+      DASHARO_VAR_FAN_CURVE_OPTION,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -522,7 +497,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption = mFanCurveOptionDefault;
     Status = gRT->SetVariable (
-        mFanCurveOptionEfiVar,
+        DASHARO_VAR_FAN_CURVE_OPTION,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.FanCurveOption),
@@ -533,7 +508,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig);
   Status = gRT->GetVariable (
-      mIommuConfigEfiVar,
+      DASHARO_VAR_IOMMU_CONFIG,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -544,7 +519,7 @@ DasharoSystemFeaturesUiLibConstructor (
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig.IommuEnable = mIommuEnableDefault;
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig.IommuHandoff = mIommuHandoffDefault;
     Status = gRT->SetVariable (
-        mIommuConfigEfiVar,
+        DASHARO_VAR_IOMMU_CONFIG,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.IommuConfig),
@@ -555,7 +530,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType);
   Status = gRT->GetVariable (
-      mSleepTypeEfiVar,
+      DASHARO_VAR_SLEEP_TYPE,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -565,7 +540,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType = mSleepTypeDefault;
     Status = gRT->SetVariable (
-        mSleepTypeEfiVar,
+        DASHARO_VAR_SLEEP_TYPE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType),
@@ -576,7 +551,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState);
   Status = gRT->GetVariable (
-      mPowerFailureStateEfiVar,
+      DASHARO_VAR_POWER_FAILURE_STATE,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -588,7 +563,7 @@ DasharoSystemFeaturesUiLibConstructor (
         FixedPcdGet8 (PcdDefaultPowerFailureState);
 
     Status = gRT->SetVariable (
-        mPowerFailureStateEfiVar,
+        DASHARO_VAR_POWER_FAILURE_STATE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.PowerFailureState),
@@ -599,7 +574,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled);
   Status = gRT->GetVariable (
-      mResizeableBarsEnabledEfiVar,
+      DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -609,7 +584,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled = mResizeableBarsEnabledDefault;
     Status = gRT->SetVariable (
-        mResizeableBarsEnabledEfiVar,
+        DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.ResizeableBarsEnabled),
@@ -620,7 +595,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera);
   Status = gRT->GetVariable (
-    mEnableCameraEfiVar,
+    DASHARO_VAR_ENABLE_CAMERA,
     &gDasharoSystemFeaturesGuid,
     NULL,
     &BufferSize,
@@ -630,7 +605,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera = mEnableCameraDefault;
     Status = gRT->SetVariable (
-        mEnableCameraEfiVar,
+        DASHARO_VAR_ENABLE_CAMERA,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableCamera),
@@ -641,7 +616,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt);
   Status = gRT->GetVariable (
-      mEnableWifiBtEfiVar,
+      DASHARO_VAR_ENABLE_WIFI_BT,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -651,7 +626,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt = mEnableWifiBtDefault;
     Status = gRT->SetVariable (
-        mEnableWifiBtEfiVar,
+        DASHARO_VAR_ENABLE_WIFI_BT,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.EnableWifiBt),
@@ -662,7 +637,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig);
   Status = gRT->GetVariable (
-    mBatteryConfigEfiVar,
+    DASHARO_VAR_BATTERY_CONFIG,
     &gDasharoSystemFeaturesGuid,
     NULL,
     &BufferSize,
@@ -673,7 +648,7 @@ DasharoSystemFeaturesUiLibConstructor (
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig.StartThreshold = mBatteryStartThresholdDefault;
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig.StopThreshold = mBatteryStopThresholdDefault;
     Status = gRT->SetVariable (
-        mBatteryConfigEfiVar,
+        DASHARO_VAR_BATTERY_CONFIG,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.BatteryConfig),
@@ -684,7 +659,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile);
   Status = gRT->GetVariable (
-      mMemoryProfileEfiVar,
+      DASHARO_VAR_MEMORY_PROFILE,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -694,7 +669,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile = mMemoryProfileDefault;
     Status = gRT->SetVariable (
-        mMemoryProfileEfiVar,
+        DASHARO_VAR_MEMORY_PROFILE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.MemoryProfile),
@@ -705,7 +680,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection);
   Status = gRT->GetVariable (
-      mSerialRedirectionEfiVar,
+      DASHARO_VAR_SERIAL_REDIRECTION,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -715,7 +690,7 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection = PcdGetBool (PcdSerialRedirectionDefaultState);
     Status = gRT->SetVariable (
-        mSerialRedirectionEfiVar,
+        DASHARO_VAR_SERIAL_REDIRECTION,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPortRedirection),
@@ -727,7 +702,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection);
   Status = gRT->GetVariable (
-      mSerialRedirection2EfiVar,
+      DASHARO_VAR_SERIAL_REDIRECTION2,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -739,7 +714,7 @@ DasharoSystemFeaturesUiLibConstructor (
                                                                                 PcdGetBool (PcdSerialRedirection2DefaultState) :
                                                                                 FALSE;
     Status = gRT->SetVariable (
-        mSerialRedirection2EfiVar,
+        DASHARO_VAR_SERIAL_REDIRECTION2,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SerialPort2Redirection),
@@ -750,7 +725,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold);
   Status = gRT->GetVariable (
-      mCpuThrottlingThresholdEfiVar,
+      DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
       &gDasharoSystemFeaturesGuid,
       NULL,
       &BufferSize,
@@ -760,11 +735,53 @@ DasharoSystemFeaturesUiLibConstructor (
   if (Status == EFI_NOT_FOUND) {
     mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold = mCpuThrottlingThresholdDefault;
     Status = gRT->SetVariable (
-        mCpuThrottlingThresholdEfiVar,
+        DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold),
         &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuThrottlingThreshold
+        );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature);
+  Status = gRT->GetVariable (
+      DASHARO_VAR_CPU_MAX_TEMPERATURE,
+      &gDasharoSystemFeaturesGuid,
+      NULL,
+      &BufferSize,
+      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature
+  );
+
+  if (Status == EFI_NOT_FOUND) {
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature = FixedPcdGet8(PcdCpuMaxTemperature);
+    Status = gRT->SetVariable (
+        DASHARO_VAR_CPU_MAX_TEMPERATURE,
+        &gDasharoSystemFeaturesGuid,
+        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature),
+        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMaxTemperature
+        );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  BufferSize = sizeof(mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold);
+  Status = gRT->GetVariable (
+      DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD,
+      &gDasharoSystemFeaturesGuid,
+      NULL,
+      &BufferSize,
+      &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold
+  );
+
+  if (Status == EFI_NOT_FOUND) {
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold = FixedPcdGet8(PcdCpuMaxTemperature) - 63;
+    Status = gRT->SetVariable (
+        DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD,
+        &gDasharoSystemFeaturesGuid,
+        EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+        sizeof (mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold),
+        &mDasharoSystemFeaturesPrivate.DasharoFeaturesData.CpuMinThrottlingThreshold
         );
     ASSERT_EFI_ERROR (Status);
   }
@@ -957,7 +974,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.LockBios != DasharoFeaturesData.LockBios) {
     Status = gRT->SetVariable (
-        mLockBiosEfiVar,
+        DASHARO_VAR_LOCK_BIOS,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.LockBios),
@@ -970,7 +987,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.SmmBwp != DasharoFeaturesData.SmmBwp) {
     Status = gRT->SetVariable (
-        mSmmBwpEfiVar,
+        DASHARO_VAR_SMM_BWP,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.SmmBwp),
@@ -983,7 +1000,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.NetworkBoot != DasharoFeaturesData.NetworkBoot) {
     Status = gRT->SetVariable (
-        mNetworkBootEfiVar,
+        DASHARO_VAR_NETWORK_BOOT,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.NetworkBoot),
@@ -996,7 +1013,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.UsbStack != DasharoFeaturesData.UsbStack) {
     Status = gRT->SetVariable (
-        mUsbStackEfiVar,
+        DASHARO_VAR_USB_STACK,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.UsbStack),
@@ -1009,7 +1026,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.UsbMassStorage != DasharoFeaturesData.UsbMassStorage) {
     Status = gRT->SetVariable (
-        mUsbMassStorageEfiVar,
+        DASHARO_VAR_USB_MASS_STORAGE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.UsbMassStorage),
@@ -1022,7 +1039,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.MeMode != DasharoFeaturesData.MeMode) {
     Status = gRT->SetVariable (
-        mMeModeEfiVar,
+        DASHARO_VAR_ME_MODE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.MeMode),
@@ -1035,7 +1052,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.Ps2Controller != DasharoFeaturesData.Ps2Controller) {
     Status = gRT->SetVariable (
-        mPs2ControllerEfiVar,
+        DASHARO_VAR_PS2_CONTROLLER,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.Ps2Controller),
@@ -1048,7 +1065,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.FanCurveOption != DasharoFeaturesData.FanCurveOption) {
     Status = gRT->SetVariable (
-        mFanCurveOptionEfiVar,
+        DASHARO_VAR_FAN_CURVE_OPTION,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.FanCurveOption),
@@ -1061,7 +1078,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.BootManagerEnabled != DasharoFeaturesData.BootManagerEnabled) {
     Status = gRT->SetVariable (
-        mBootManagerEnabledEfiVar,
+        DASHARO_VAR_BOOT_MANAGER_ENABLED,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.BootManagerEnabled),
@@ -1077,7 +1094,7 @@ DasharoSystemFeaturesRouteConfig (
       Private->DasharoFeaturesData.WatchdogConfig.WatchdogTimeout !=
         DasharoFeaturesData.WatchdogConfig.WatchdogTimeout) {
     Status = gRT->SetVariable (
-        mWatchdogEfiVar,
+        DASHARO_VAR_WATCHDOG,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.WatchdogConfig),
@@ -1091,7 +1108,7 @@ DasharoSystemFeaturesRouteConfig (
   if (Private->DasharoFeaturesData.IommuConfig.IommuEnable != DasharoFeaturesData.IommuConfig.IommuEnable ||
       Private->DasharoFeaturesData.IommuConfig.IommuHandoff != DasharoFeaturesData.IommuConfig.IommuHandoff) {
     Status = gRT->SetVariable (
-        mIommuConfigEfiVar,
+        DASHARO_VAR_IOMMU_CONFIG,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.IommuConfig),
@@ -1104,7 +1121,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.SleepType != DasharoFeaturesData.SleepType) {
     Status = gRT->SetVariable (
-        mSleepTypeEfiVar,
+        DASHARO_VAR_SLEEP_TYPE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.SleepType),
@@ -1117,7 +1134,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.PowerFailureState != DasharoFeaturesData.PowerFailureState) {
     Status = gRT->SetVariable (
-        mPowerFailureStateEfiVar,
+        DASHARO_VAR_POWER_FAILURE_STATE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.PowerFailureState),
@@ -1130,7 +1147,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.EnableWifiBt != DasharoFeaturesData.EnableWifiBt) {
     Status = gRT->SetVariable (
-        mEnableWifiBtEfiVar,
+        DASHARO_VAR_ENABLE_WIFI_BT,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.EnableWifiBt),
@@ -1143,7 +1160,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.ResizeableBarsEnabled != DasharoFeaturesData.ResizeableBarsEnabled) {
     Status = gRT->SetVariable (
-        mResizeableBarsEnabledEfiVar,
+        DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.ResizeableBarsEnabled),
@@ -1156,7 +1173,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.OptionRomExecution != DasharoFeaturesData.OptionRomExecution) {
     Status = gRT->SetVariable (
-        mOptionRomPolicyEfiVar,
+        DASHARO_VAR_OPTION_ROM_POLICY,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.OptionRomExecution),
@@ -1169,7 +1186,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if(Private->DasharoFeaturesData.EnableCamera != DasharoFeaturesData.EnableCamera) {
     Status = gRT->SetVariable (
-        mEnableCameraEfiVar,
+        DASHARO_VAR_ENABLE_CAMERA,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.EnableCamera),
@@ -1185,7 +1202,7 @@ DasharoSystemFeaturesRouteConfig (
       Private->DasharoFeaturesData.BatteryConfig.StopThreshold !=
         DasharoFeaturesData.BatteryConfig.StopThreshold) {
     Status = gRT->SetVariable (
-        mBatteryConfigEfiVar,
+        DASHARO_VAR_BATTERY_CONFIG,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.BatteryConfig),
@@ -1198,7 +1215,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.MemoryProfile != DasharoFeaturesData.MemoryProfile) {
     Status = gRT->SetVariable (
-        mMemoryProfileEfiVar,
+        DASHARO_VAR_MEMORY_PROFILE,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.MemoryProfile),
@@ -1211,7 +1228,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.SerialPortRedirection != DasharoFeaturesData.SerialPortRedirection) {
     Status = gRT->SetVariable (
-        mSerialRedirectionEfiVar,
+        DASHARO_VAR_SERIAL_REDIRECTION,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.SerialPortRedirection),
@@ -1224,7 +1241,7 @@ DasharoSystemFeaturesRouteConfig (
 
   if (Private->DasharoFeaturesData.SerialPort2Redirection != DasharoFeaturesData.SerialPort2Redirection) {
     Status = gRT->SetVariable (
-        mSerialRedirection2EfiVar,
+        DASHARO_VAR_SERIAL_REDIRECTION2,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.SerialPort2Redirection),
@@ -1238,7 +1255,7 @@ DasharoSystemFeaturesRouteConfig (
   if (Private->DasharoFeaturesData.CpuThrottlingThreshold !=
         DasharoFeaturesData.CpuThrottlingThreshold) {
     Status = gRT->SetVariable (
-        mCpuThrottlingThresholdEfiVar,
+        DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
         &gDasharoSystemFeaturesGuid,
         EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
         sizeof (DasharoFeaturesData.CpuThrottlingThreshold),
@@ -1420,7 +1437,7 @@ DasharoSystemFeaturesCallback (
 
         if (Key.UnicodeChar == CHAR_CARRIAGE_RETURN) {
           Status = gRT->SetVariable (
-              mFirmwareUpdateModeEfiVar,
+              DASHARO_VAR_FIRMWARE_UPDATE_MODE,
               &gDasharoSystemFeaturesGuid,
               EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE,
               sizeof (Enable),

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -24,7 +24,6 @@ STATIC UINT8     mFanCurveOptionDefault = FAN_CURVE_OPTION_SILENT;
 STATIC UINT8     mIommuEnableDefault = FALSE;
 STATIC UINT8     mIommuHandoffDefault = FALSE;
 STATIC BOOLEAN   mBootManagerEnabledDefault = TRUE;
-STATIC UINT8     mSleepTypeDefault = SLEEP_TYPE_S0IX;
 STATIC UINT8     mResizeableBarsEnabledDefault = FALSE;
 STATIC BOOLEAN   mEnableCameraDefault = TRUE;
 STATIC BOOLEAN   mEnableWifiBtDefault = TRUE;
@@ -538,7 +537,9 @@ DasharoSystemFeaturesUiLibConstructor (
       );
 
   if (Status == EFI_NOT_FOUND) {
-    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType = mSleepTypeDefault;
+    mDasharoSystemFeaturesPrivate.DasharoFeaturesData.SleepType = PcdGetBool (PcdSleepTypeDefaultS3)
+                                                                ? SLEEP_TYPE_S3
+                                                                : SLEEP_TYPE_S0IX;
     Status = gRT->SetVariable (
         DASHARO_VAR_SLEEP_TYPE,
         &gDasharoSystemFeaturesGuid,

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -27,26 +27,6 @@ SPDX-License-Identifier: BSD-2-Clause
 
 #define DASHARO_FEATURES_DATA_VARSTORE_ID      0x0001
 
-#pragma pack(push,1)
-typedef struct {
-  BOOLEAN WatchdogEnable;
-  UINT16  WatchdogTimeout;
-} WATCHDOG_CONFIG;
-
-typedef struct {
-  BOOLEAN IommuEnable;
-  BOOLEAN IommuHandoff;
-} IOMMU_CONFIG;
-
-typedef struct {
-  UINT8  StartThreshold;
-  UINT8  StopThreshold;
-} BATTERY_CONFIG;
-#pragma pack(pop)
-
-#define FAN_CURVE_OPTION_SILENT 0
-#define FAN_CURVE_OPTION_PERFORMANCE 1
-
 typedef struct {
   // Feature visibility
   BOOLEAN            ShowSecurityMenu;
@@ -74,55 +54,66 @@ typedef struct {
   BOOLEAN            S3SupportExperimental;
   BOOLEAN            Have2ndUart;
   BOOLEAN            ShowCpuThrottlingThreshold;
+
   // Feature data
-  BOOLEAN            LockBios;
-  BOOLEAN            SmmBwp;
-  BOOLEAN            NetworkBoot;
-  BOOLEAN            UsbStack;
-  BOOLEAN            UsbMassStorage;
-  UINT8              MeMode;
-  BOOLEAN            Ps2Controller;
-  WATCHDOG_CONFIG    WatchdogConfig;
-  BOOLEAN            WatchdogAvailable;
-  UINT8              FanCurveOption;
-  IOMMU_CONFIG       IommuConfig;
-  BOOLEAN            BootManagerEnabled;
-  UINT8              SleepType;
-  UINT8              PowerFailureState;
-  BOOLEAN            ResizeableBarsEnabled;
-  UINT8              OptionRomExecution;
-  BOOLEAN            EnableCamera;
-  BOOLEAN            EnableWifiBt;
-  BATTERY_CONFIG     BatteryConfig;
-  UINT8              MemoryProfile;
-  BOOLEAN            SerialPortRedirection;
-  BOOLEAN            SerialPort2Redirection;
-  UINT8              CpuThrottlingThreshold;
-  UINT8              CpuMaxTemperature;
-  UINT8              CpuMinThrottlingThreshold;
+  BOOLEAN                  LockBios;
+  BOOLEAN                  SmmBwp;
+  BOOLEAN                  NetworkBoot;
+  BOOLEAN                  UsbStack;
+  BOOLEAN                  UsbMassStorage;
+  UINT8                    MeMode;
+  BOOLEAN                  Ps2Controller;
+  DASHARO_WATCHDOG_CONFIG  WatchdogConfig;
+  BOOLEAN                  WatchdogAvailable;
+  UINT8                    FanCurveOption;
+  DASHARO_IOMMU_CONFIG     IommuConfig;
+  BOOLEAN                  BootManagerEnabled;
+  UINT8                    SleepType;
+  UINT8                    PowerFailureState;
+  BOOLEAN                  ResizeableBarsEnabled;
+  UINT8                    OptionRomExecution;
+  BOOLEAN                  EnableCamera;
+  BOOLEAN                  EnableWifiBt;
+  DASHARO_BATTERY_CONFIG   BatteryConfig;
+  UINT8                    MemoryProfile;
+  BOOLEAN                  SerialPortRedirection;
+  BOOLEAN                  SerialPort2Redirection;
+  UINT8                    CpuThrottlingThreshold;
+  UINT8                    CpuMaxTemperature;
+  UINT8                    CpuMinThrottlingThreshold;
 } DASHARO_FEATURES_DATA;
 
-#define ME_MODE_ENABLE        0
-#define ME_MODE_DISABLE_HECI  1
-#define ME_MODE_DISABLE_HAP   2
+//
+// DasharoOptions.h can be included by files unrelated to Dasharo in which case
+// it's useful to indicate where they came from.
+//
+// HII code, however, is already specific to Dasharo and there is no need to
+// have extra 8 characters here.
+//
+
+#define FAN_CURVE_OPTION_SILENT        DASHARO_FAN_CURVE_OPTION_SILENT
+#define FAN_CURVE_OPTION_PERFORMANCE   DASHARO_FAN_CURVE_OPTION_PERFORMANCE
+
+#define ME_MODE_ENABLE                 DASHARO_ME_MODE_ENABLE
+#define ME_MODE_DISABLE_HECI           DASHARO_ME_MODE_DISABLE_HECI
+#define ME_MODE_DISABLE_HAP            DASHARO_ME_MODE_DISABLE_HAP
 
 #define OPTION_ROM_POLICY_DISABLE_ALL  DASHARO_OPTION_ROM_POLICY_DISABLE_ALL
 #define OPTION_ROM_POLICY_ENABLE_ALL   DASHARO_OPTION_ROM_POLICY_ENABLE_ALL
 #define OPTION_ROM_POLICY_VGA_ONLY     DASHARO_OPTION_ROM_POLICY_VGA_ONLY
 
-#define SLEEP_TYPE_S0IX  0
-#define SLEEP_TYPE_S3    1
+#define SLEEP_TYPE_S0IX                DASHARO_SLEEP_TYPE_S0IX
+#define SLEEP_TYPE_S3                  DASHARO_SLEEP_TYPE_S3
 
-#define POWER_FAILURE_STATE_OFF     0
-#define POWER_FAILURE_STATE_ON      1
-#define POWER_FAILURE_STATE_KEEP    2
-#define POWER_FAILURE_STATE_HIDDEN  0xff
+#define POWER_FAILURE_STATE_OFF        DASHARO_POWER_FAILURE_STATE_OFF
+#define POWER_FAILURE_STATE_ON         DASHARO_POWER_FAILURE_STATE_ON
+#define POWER_FAILURE_STATE_KEEP       DASHARO_POWER_FAILURE_STATE_KEEP
+#define POWER_FAILURE_STATE_HIDDEN     DASHARO_POWER_FAILURE_STATE_HIDDEN
 
-// Values aren't random, they match FSP_M_CONFIG::SpdProfileSelected
-#define MEMORY_PROFILE_JEDEC  0
-#define MEMORY_PROFILE_XMP1   2
-#define MEMORY_PROFILE_XMP2   3
-#define MEMORY_PROFILE_XMP3   4
+#define MEMORY_PROFILE_JEDEC           DASHARO_MEMORY_PROFILE_JEDEC
+#define MEMORY_PROFILE_XMP1            DASHARO_MEMORY_PROFILE_XMP1
+#define MEMORY_PROFILE_XMP2            DASHARO_MEMORY_PROFILE_XMP2
+#define MEMORY_PROFILE_XMP3            DASHARO_MEMORY_PROFILE_XMP3
 
 #define NETWORK_BOOT_QUESTION_ID             0x8000
 #define WATCHDOG_ENABLE_QUESTION_ID         0x8001

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -29,31 +29,31 @@ SPDX-License-Identifier: BSD-2-Clause
 
 typedef struct {
   // Feature visibility
-  BOOLEAN            ShowSecurityMenu;
-  BOOLEAN            ShowIntelMeMenu;
-  BOOLEAN            ShowUsbMenu;
-  BOOLEAN            ShowNetworkMenu;
-  BOOLEAN            ShowChipsetMenu;
-  BOOLEAN            ShowPowerMenu;
-  BOOLEAN            ShowPciMenu;
-  BOOLEAN            ShowMemoryMenu;
-  BOOLEAN            ShowSerialPortMenu;
-  BOOLEAN            ShowLockBios;
-  BOOLEAN            ShowSmmBwp;
-  BOOLEAN            ShowFum;
-  BOOLEAN            ShowPs2Option;
-  BOOLEAN            PowerMenuShowFanCurve;
-  BOOLEAN            PowerMenuShowSleepType;
-  BOOLEAN            PowerMenuShowBatteryThresholds;
-  BOOLEAN            DasharoEnterprise;
-  BOOLEAN            SecurityMenuShowIommu;
-  BOOLEAN            PciMenuShowResizeableBars;
-  BOOLEAN            SecurityMenuShowWiFiBt;
-  BOOLEAN            SecurityMenuShowCamera;
-  BOOLEAN            MeHapAvailable;
-  BOOLEAN            S3SupportExperimental;
-  BOOLEAN            Have2ndUart;
-  BOOLEAN            ShowCpuThrottlingThreshold;
+  BOOLEAN  ShowSecurityMenu;
+  BOOLEAN  ShowIntelMeMenu;
+  BOOLEAN  ShowUsbMenu;
+  BOOLEAN  ShowNetworkMenu;
+  BOOLEAN  ShowChipsetMenu;
+  BOOLEAN  ShowPowerMenu;
+  BOOLEAN  ShowPciMenu;
+  BOOLEAN  ShowMemoryMenu;
+  BOOLEAN  ShowSerialPortMenu;
+  BOOLEAN  ShowLockBios;
+  BOOLEAN  ShowSmmBwp;
+  BOOLEAN  ShowFum;
+  BOOLEAN  ShowPs2Option;
+  BOOLEAN  PowerMenuShowFanCurve;
+  BOOLEAN  PowerMenuShowSleepType;
+  BOOLEAN  PowerMenuShowBatteryThresholds;
+  BOOLEAN  DasharoEnterprise;
+  BOOLEAN  SecurityMenuShowIommu;
+  BOOLEAN  PciMenuShowResizeableBars;
+  BOOLEAN  SecurityMenuShowWiFiBt;
+  BOOLEAN  SecurityMenuShowCamera;
+  BOOLEAN  MeHapAvailable;
+  BOOLEAN  S3SupportExperimental;
+  BOOLEAN  Have2ndUart;
+  BOOLEAN  ShowCpuThrottlingThreshold;
 
   // Feature data
   BOOLEAN                  LockBios;
@@ -115,8 +115,14 @@ typedef struct {
 #define MEMORY_PROFILE_XMP2            DASHARO_MEMORY_PROFILE_XMP2
 #define MEMORY_PROFILE_XMP3            DASHARO_MEMORY_PROFILE_XMP3
 
+//
+// Question IDs are used in VFR file to let the code in
+// DasharoSystemFeaturesCallback() know what form element caused
+// invocation of the callback.
+//
+
 #define NETWORK_BOOT_QUESTION_ID             0x8000
-#define WATCHDOG_ENABLE_QUESTION_ID         0x8001
+#define WATCHDOG_ENABLE_QUESTION_ID          0x8001
 #define WATCHDOG_TIMEOUT_QUESTION_ID         0x8002
 #define FIRMWARE_UPDATE_MODE_QUESTION_ID     0x8003
 #define POWER_FAILURE_STATE_QUESTION_ID      0x8004
@@ -127,7 +133,5 @@ typedef struct {
 #define INTEL_ME_MODE_QUESTION_ID            0x8009
 #define SLEEP_TYPE_QUESTION_ID               0x800A
 #define SERIAL_PORT2_REDIR_QUESTION_ID       0x800B
-
-extern EFI_GUID gDasharoSystemFeaturesGuid;
 
 #endif

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -47,6 +47,7 @@
   PrintLib
   HiiLib
   UefiHiiServicesLib
+  DasharoVariablesLib
 
 [Guids]
   gEfiHiiPlatformSetupFormsetGuid               ## CONSUMES ## GUID (Indicate the formset class guid to be displayed)
@@ -71,29 +72,20 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowSerialPortMenu
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowFanCurve
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowSleepType
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultPowerFailureState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDasharoEnterprise
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowIommuOptions
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPciMenuShowResizeableBars
   gDasharoSystemFeaturesTokenSpaceGuid.PcdPowerMenuShowBatteryThresholds
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirectionDefaultState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowWiFiBtOption
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSecurityShowCameraOption
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeDefaultState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeHapAvailable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdS3SupportExperimental
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowLockBios
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowSmmBwp
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowFum
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowPs2Option
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdSleepTypeDefaultS3
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirection2DefaultState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdHave2ndUart
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtEnableDefault
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuThrottlingThreshold
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuMaxTemperature
-
-  gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -243,7 +243,7 @@ formset
                questionid = WATCHDOG_ENABLE_QUESTION_ID,
                prompt  = STRING_TOKEN(STR_WATCHDOG_ENABLE_PROMPT),
                help    = STRING_TOKEN(STR_WATCHDOG_ENABLE_HELP),
-               flags   = RESET_REQUIRED,
+               flags   = RESET_REQUIRED | INTERACTIVE,
       endcheckbox;
 
       suppressif ideqval FeaturesData.WatchdogConfig.WatchdogEnable == 0;

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -11,9 +11,18 @@
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TpmMeasurementLib.h>
+#include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 
 #include <DasharoOptions.h>
+
+// PCR number for Dasharo variables.
+#define DASHARO_VAR_PCR  1
+
+// Event type for Dasharo variables.
+#define EV_DASHARO_VAR  0x00DA0000
 
 // Description of a single variable.
 typedef struct {
@@ -265,6 +274,134 @@ InitVariable (
     Status = ResetVariable (VarName);
     ASSERT_EFI_ERROR (Status);
   }
+}
+
+/**
+  Measure a single variable into DASHARO_VAR_PCR with EV_DASHARO_VAR event type.
+
+  @param VarName  Name of the variable.
+  @param Vendor   Namespace of the variable.
+
+  @retval EFI_SUCCESS  If the variable was read and measured without errors.
+  @retval EFI_OUT_OF_RESOURCES  On memory allocation failure.
+**/
+STATIC
+EFI_STATUS
+MeasureVariable (
+  CHAR16    *VarName,
+  EFI_GUID  *Vendor
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       PrefixSize;
+  VOID        *VarData;
+  UINTN       VarSize;
+  CHAR8       *EventData;
+
+  DEBUG ((EFI_D_VERBOSE, "%a(): %g:%s.\r\n", __FUNCTION__, Vendor, VarName));
+
+  PrefixSize = StrLen (VarName) + 1;
+
+  Status = GetVariable2 (VarName, Vendor, &VarData, &VarSize);
+  ASSERT_EFI_ERROR (Status);
+
+  EventData = AllocatePool (PrefixSize + VarSize);
+  if (EventData == NULL) {
+    FreePool (VarData);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  UnicodeStrToAsciiStrS (VarName, EventData, PrefixSize);
+  CopyMem (EventData + PrefixSize, VarData, VarSize);
+
+  Status = TpmMeasureAndLogData (
+      DASHARO_VAR_PCR,
+      EV_DASHARO_VAR,
+      EventData,
+      PrefixSize + VarSize,
+      VarData,
+      VarSize
+      );
+
+  FreePool (EventData);
+  FreePool (VarData);
+
+  return Status;
+}
+
+/**
+  Measures single all existing variables with the specified GUID.
+
+  @param Vendor   Namespace of the variable.
+
+  @retval EFI_SUCCESS  If the variable was read and measured without errors.
+**/
+STATIC
+EFI_STATUS
+MeasureVariables (
+  EFI_GUID  *Vendor
+  )
+{
+  EFI_STATUS  Status;
+  CHAR16      *Name;
+  CHAR16      *NewBuf;
+  UINTN       MaxNameSize;
+  UINTN       NameSize;
+  EFI_GUID    Guid;
+
+  MaxNameSize = 32*sizeof (CHAR16);
+  Name = AllocateZeroPool (MaxNameSize);
+  if (Name == NULL)
+    return EFI_OUT_OF_RESOURCES;
+
+  while (TRUE) {
+    NameSize = MaxNameSize;
+    Status = gRT->GetNextVariableName (&NameSize, Name, &Guid);
+    if (Status == EFI_BUFFER_TOO_SMALL) {
+      NewBuf = AllocatePool (NameSize);
+      if (NewBuf == NULL) {
+        Status = EFI_OUT_OF_RESOURCES;
+        break;
+      }
+
+      StrnCpyS (NewBuf, NameSize/sizeof (CHAR16), Name, MaxNameSize/sizeof (CHAR16));
+      FreePool (Name);
+
+      Name = NewBuf;
+      MaxNameSize = NameSize;
+
+      Status = gRT->GetNextVariableName (&NameSize, Name, &Guid);
+    }
+
+    if (Status == EFI_NOT_FOUND) {
+      Status = EFI_SUCCESS;
+      break;
+    }
+
+    if (EFI_ERROR (Status))
+      break;
+
+    if (CompareGuid (&Guid, Vendor))
+      MeasureVariable (Name, Vendor);
+  }
+
+  FreePool (Name);
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+DasharoMeasureVariables (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = MeasureVariables (&gDasharoSystemFeaturesGuid);
+  if (Status == EFI_SUCCESS)
+    Status = MeasureVariables (&gApuConfigurationFormsetGuid);
+
+  return Status;
 }
 
 EFI_STATUS

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -6,6 +6,8 @@
 
 **/
 
+#include "Library/DasharoVariablesLib.h"
+
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
@@ -169,6 +171,22 @@ GetVariableInfo (
   Value.Attributes = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE | ExtraAttrs;
 
   return Value;
+}
+
+DASHARO_VAR_DATA
+EFIAPI
+DasharoGetVariableDefault (
+  CHAR16  *VarName
+  )
+{
+  VAR_INFO  VarInfo;
+
+  VarInfo = GetVariableInfo (VarName);
+  if (VarInfo.Size == 0) {
+    DEBUG ((EFI_D_VERBOSE, "%a(): Failed to look up default for %s.\n", __FUNCTION__, VarName));
+  }
+
+  return VarInfo.Data;
 }
 
 /**

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -1,0 +1,251 @@
+/** @file
+  A library for providing services related to Dasharo-specific EFI variables.
+
+  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+
+#include <DasharoOptions.h>
+
+// Description of a single variable.
+typedef struct {
+  // Default value.
+  DASHARO_VAR_DATA  Data;  // Value for the variable.
+  UINTN             Size;  // Number of bytes of Data actually used.
+
+  UINT32  Attributes;  // EFI variable attributes for this variable.
+} VAR_INFO;
+
+// List of all Dasharo EFI variables in gDasharoSystemFeaturesGuid namespace.
+STATIC CHAR16 *mAllVariables[] = {
+  DASHARO_VAR_BATTERY_CONFIG,
+  DASHARO_VAR_BOOT_MANAGER_ENABLED,
+  DASHARO_VAR_CPU_MAX_TEMPERATURE,
+  DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD,
+  DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
+  DASHARO_VAR_ENABLE_CAMERA,
+  DASHARO_VAR_ENABLE_WIFI_BT,
+  DASHARO_VAR_FAN_CURVE_OPTION,
+  DASHARO_VAR_FIRMWARE_UPDATE_MODE,
+  DASHARO_VAR_IOMMU_CONFIG,
+  DASHARO_VAR_LOCK_BIOS,
+  DASHARO_VAR_MEMORY_PROFILE,
+  DASHARO_VAR_ME_MODE,
+  DASHARO_VAR_NETWORK_BOOT,
+  DASHARO_VAR_OPTION_ROM_POLICY,
+  DASHARO_VAR_POWER_FAILURE_STATE,
+  DASHARO_VAR_PS2_CONTROLLER,
+  DASHARO_VAR_RESIZEABLE_BARS_ENABLED,
+  DASHARO_VAR_SERIAL_REDIRECTION,
+  DASHARO_VAR_SERIAL_REDIRECTION2,
+  DASHARO_VAR_SLEEP_TYPE,
+  DASHARO_VAR_SMM_BWP,
+  DASHARO_VAR_USB_MASS_STORAGE,
+  DASHARO_VAR_USB_STACK,
+  DASHARO_VAR_WATCHDOG,
+  DASHARO_VAR_WATCHDOG_AVAILABLE,
+};
+
+/**
+  Produce a default value for a specified variable.
+
+  @param VarName  Name of the variable.
+
+  @retval Default value and its length which is zero for unknown variable name.
+**/
+STATIC
+VAR_INFO
+GetVariableInfo (
+  CHAR16  *VarName
+  )
+{
+  VAR_INFO          Value;
+  DASHARO_VAR_DATA  Data;
+  UINTN             Size;
+  UINT32            ExtraAttrs;
+
+  SetMem (&Data, sizeof (Data), 0);
+  Size = 0;
+  ExtraAttrs = 0;
+
+  if (StrCmp (VarName, DASHARO_VAR_BATTERY_CONFIG) == 0) {
+    Data.Battery.StartThreshold = 95;
+    Data.Battery.StopThreshold = 98;
+    Size = sizeof (Data.Battery);
+  } else if (StrCmp (VarName, DASHARO_VAR_BOOT_MANAGER_ENABLED) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_CPU_MAX_TEMPERATURE) == 0) {
+    Data.Uint8 = FixedPcdGet8 (PcdCpuMaxTemperature);
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD) == 0) {
+    Data.Uint8 = FixedPcdGet8 (PcdCpuMaxTemperature) - 63;
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_CPU_THROTTLING_THRESHOLD) == 0) {
+    Data.Uint8 = 80;
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_ENABLE_CAMERA) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_ENABLE_WIFI_BT) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_FAN_CURVE_OPTION) == 0) {
+    Data.Uint8 = DASHARO_FAN_CURVE_OPTION_SILENT;
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_FIRMWARE_UPDATE_MODE) == 0) {
+    Data.Boolean = FALSE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_IOMMU_CONFIG) == 0) {
+    Data.Iommu.IommuEnable = FALSE;
+    Data.Iommu.IommuHandoff = FALSE;
+    Size = sizeof (Data.Iommu);
+  } else if (StrCmp (VarName, DASHARO_VAR_LOCK_BIOS) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_MEMORY_PROFILE) == 0) {
+    Data.Uint8 = DASHARO_MEMORY_PROFILE_JEDEC;
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_ME_MODE) == 0) {
+    Data.Uint8 = FixedPcdGet8 (PcdIntelMeDefaultState);
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_NETWORK_BOOT) == 0) {
+    Data.Boolean = PcdGetBool (PcdDefaultNetworkBootEnable);
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_OPTION_ROM_POLICY) == 0) {
+    Data.Uint8 = PcdGetBool (PcdLoadOptionRoms)
+      ? DASHARO_OPTION_ROM_POLICY_ENABLE_ALL
+      : DASHARO_OPTION_ROM_POLICY_DISABLE_ALL;
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_POWER_FAILURE_STATE) == 0) {
+    Data.Uint8 = FixedPcdGet8 (PcdDefaultPowerFailureState);
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_PS2_CONTROLLER) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_RESIZEABLE_BARS_ENABLED) == 0) {
+    Data.Boolean = FALSE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_SERIAL_REDIRECTION) == 0) {
+    Data.Boolean = PcdGetBool (PcdSerialRedirectionDefaultState);
+    Size = sizeof (Data.Boolean);
+    ExtraAttrs = EFI_VARIABLE_RUNTIME_ACCESS;
+  } else if (StrCmp (VarName, DASHARO_VAR_SERIAL_REDIRECTION2) == 0) {
+    Data.Boolean = PcdGetBool (PcdHave2ndUart) ? PcdGetBool (PcdSerialRedirection2DefaultState) : FALSE;
+    Size = sizeof (Data.Boolean);
+    ExtraAttrs = EFI_VARIABLE_RUNTIME_ACCESS;
+  } else if (StrCmp (VarName, DASHARO_VAR_SLEEP_TYPE) == 0) {
+    Data.Uint8 = PcdGetBool (PcdSleepTypeDefaultS3) ? DASHARO_SLEEP_TYPE_S3 : DASHARO_SLEEP_TYPE_S0IX;
+    Size = sizeof (Data.Uint8);
+  } else if (StrCmp (VarName, DASHARO_VAR_SMM_BWP) == 0) {
+    Data.Boolean = FALSE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_USB_MASS_STORAGE) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_USB_STACK) == 0) {
+    Data.Boolean = TRUE;
+    Size = sizeof (Data.Boolean);
+  } else if (StrCmp (VarName, DASHARO_VAR_WATCHDOG) == 0) {
+    Data.Watchdog.WatchdogEnable = PcdGetBool (PcdOcWdtEnableDefault);
+    Data.Watchdog.WatchdogTimeout = FixedPcdGet16 (PcdOcWdtTimeoutDefault);
+    Size = sizeof (Data.Watchdog);
+  } else if (StrCmp (VarName, DASHARO_VAR_WATCHDOG_AVAILABLE) == 0) {
+    Data.Boolean = PcdGetBool (PcdShowOcWdtOptions);
+    Size = sizeof (Data.Boolean);
+  } else {
+    DEBUG ((EFI_D_ERROR, "%a(): Unknown variable: %s.\n", __FUNCTION__, VarName));
+    ASSERT ((0 && "No default value set for a variable."));
+  }
+
+  Value.Data = Data;
+  Value.Size = Size;
+  Value.Attributes = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE | ExtraAttrs;
+
+  return Value;
+}
+
+/**
+  Reset a single Dasharo EFI variable to its default value.
+
+  @param VarName  Name of the variable to reset.
+
+  @retval RETURN_SUCCESS  Successfully measured all variables.
+**/
+STATIC
+EFI_STATUS
+ResetVariable (
+  CHAR16 *VarName
+  )
+{
+  EFI_STATUS  Status;
+  VAR_INFO    VarInfo;
+
+  VarInfo = GetVariableInfo (VarName);
+  if (VarInfo.Size == 0)
+    return EFI_NOT_FOUND;
+
+  Status = gRT->SetVariable (
+      VarName,
+      &gDasharoSystemFeaturesGuid,
+      VarInfo.Attributes,
+      VarInfo.Size,
+      &VarInfo.Data
+      );
+
+  return Status;
+}
+
+/**
+  Check whether a specified variable exists and create it if it doesn't.
+
+  The variable is created with a default value.
+
+  @param VarName  Name of the variable to initialize.
+**/
+STATIC
+VOID
+InitVariable (
+  CHAR16  *VarName
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       BufferSize;
+
+  BufferSize = 0;
+  Status = gRT->GetVariable (
+      VarName,
+      &gDasharoSystemFeaturesGuid,
+      NULL,
+      &BufferSize,
+      NULL
+      );
+
+  if (Status == EFI_NOT_FOUND) {
+    Status = ResetVariable (VarName);
+    ASSERT_EFI_ERROR (Status);
+  }
+}
+
+EFI_STATUS
+EFIAPI
+DasharoVariablesLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  UINTN  Idx;
+
+  // Create any Dasharo-specific variables that are missing by initializing
+  // them with default values.
+  for (Idx = 0; Idx < ARRAY_SIZE (mAllVariables); Idx++)
+    InitVariable (mAllVariables[Idx]);
+
+  return EFI_SUCCESS;
+}

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -189,6 +189,22 @@ DasharoGetVariableDefault (
   return VarInfo.Data;
 }
 
+UINT32
+EFIAPI
+DasharoGetVariableAttributes (
+  CHAR16  *VarName
+  )
+{
+  VAR_INFO  VarInfo;
+
+  VarInfo = GetVariableInfo (VarName);
+  if (VarInfo.Size == 0) {
+    DEBUG ((EFI_D_VERBOSE, "%a(): Failed to look up attributes of %s.\n", __FUNCTION__, VarName));
+  }
+
+  return VarInfo.Attributes;
+}
+
 /**
   Reset a single Dasharo EFI variable to its default value.
 

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -1,0 +1,54 @@
+#
+#  A library for providing services related to Dasharo-specific EFI variables.
+#
+#  Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = DasharoVariablesLib
+  MODULE_UNI_FILE                = DasharoVariablesLib.uni
+  FILE_GUID                      = F7C51973-0F61-4955-87D2-710FD578D161
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DasharoVariablesLib|DXE_DRIVER
+  CONSTRUCTOR                    = DasharoVariablesLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  DasharoVariablesLib.c
+
+[Packages]
+  DasharoModulePkg/DasharoModulePkg.dec
+  MdePkg/MdePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  PcdLib
+
+[Guids]
+  gDasharoSystemFeaturesGuid           ### CONSUMES
+
+[Pcd]
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultPowerFailureState
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdHave2ndUart
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdIntelMeDefaultState
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtEnableDefault
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtTimeoutDefault
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirection2DefaultState
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirectionDefaultState
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuThrottlingThreshold
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdSleepTypeDefaultS3
+
+  gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -28,15 +28,19 @@
 
 [Packages]
   DasharoModulePkg/DasharoModulePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
   UefiPayloadPkg/UefiPayloadPkg.dec
 
 [LibraryClasses]
   DebugLib
+  TpmMeasurementLib
   PcdLib
+  UefiLib
 
 [Guids]
   gDasharoSystemFeaturesGuid           ### CONSUMES
+  gApuConfigurationFormsetGuid         ### SOMETIMES CONSUMES
 
 [Pcd]
   gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuMaxTemperature

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -14,7 +14,7 @@
   FILE_GUID                      = F7C51973-0F61-4955-87D2-710FD578D161
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DasharoVariablesLib|DXE_DRIVER
+  LIBRARY_CLASS                  = DasharoVariablesLib|DXE_DRIVER UEFI_APPLICATION
   CONSTRUCTOR                    = DasharoVariablesLibConstructor
 
 #
@@ -39,6 +39,7 @@
   gDasharoSystemFeaturesGuid           ### CONSUMES
 
 [Pcd]
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuMaxTemperature
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultNetworkBootEnable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdDefaultPowerFailureState
   gDasharoSystemFeaturesTokenSpaceGuid.PcdHave2ndUart

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.uni
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.uni
@@ -1,0 +1,13 @@
+// /** @file
+// A library for providing services related to Dasharo-specific EFI variables.
+//
+// Copyright (c) 2024, 3mdeb Sp. z o.o. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT     #language en-US "DasharoVariablesLib library provides services related to Dasharo-specific EFI variables."
+
+#string STR_MODULE_DESCRIPTION  #language en-US "DasharoVariablesLib library exposes list of Dasharo-specific variables and a few functions related to handling them."


### PR DESCRIPTION
Some clean up while making Dasharo variables to initialize without entering setup UI:
* Value for variable initialization and resetting now needs to be specified only in one place, getting rid of bugs when they diverge (see below).
* All string literals with variable names are now macros, so you can’t make a typo.
* Duplicated code was replaced with macros: adding a new variable now requires adding 1-2 new lines in several places.
* Add documentation on how to add a new setting.

Fixes for issues found in the process:
* SleepType was always created with SLEEP_TYPE_S0IX value but could have been reset to SLEEP_TYPE_S3 depending on a PCD.  Now initial value also takes that PCD into account.
* Watchdog enabled setting was always disabled on reset because callback was never called for it (missing INTERACTIVE flag).

The main thing was adding variable measurements in [4ded52e](https://github.com/Dasharo/DasharoModulePkg/pull/45/commits/4ded52eda922d9f657586e7e61dd660cc9752c94) and unconditional creation of variables were needed to make sure variables are always there when we want to hash them.

Sample log entries:
<details><summary>Details</summary>
<p>

```
0000: 00000000
  Event:
    PCRIndex  - 1
    EventType - 0x00DA0000
    DigestCount: 0x00000002
      HashAlgo : 0x0004
      Digest(0): 14 89 F9 23 C4 DC A7 29 17 8B 3E 32 33 45 85 50 D8 DD DF 29
      HashAlgo : 0x000B
      Digest(1): 96 A2 96 D2 24 F2 85 C6 7B EE 93 C3 0F 8A 30 91 57 F0 DA A3 5D C5 B8 7E 41 0B 78 63 0A 09 CF C7

    EventSize - 0x0000000E
0000: 496F6D6D75436F6E666967000000
  Event:
    PCRIndex  - 1
    EventType - 0x00DA0000
    DigestCount: 0x00000002
      HashAlgo : 0x0004
      Digest(0): BF 8B 45 30 D8 D2 46 DD 74 AC 53 A1 34 71 BB A1 79 41 DF F7
      HashAlgo : 0x000B
      Digest(1): 4B F5 12 2F 34 45 54 C5 3B DE 2E BB 8C D2 B7 E3 D1 60 0A D6 31 C3 85 A5 D7 CC E2 3C 77 85 45 9A

    EventSize - 0x0000000A
0000: 4C6F636B42696F730001
  Event:
    PCRIndex  - 1
    EventType - 0x00DA0000
    DigestCount: 0x00000002
      HashAlgo : 0x0004
      Digest(0): 5B A9 3C 9D B0 CF F9 3F 52 B5 21 D7 42 0E 43 F6 ED A2 78 4F
      HashAlgo : 0x000B
      Digest(1): 6E 34 0B 9C FF B3 7A 98 9C A5 44 E6 BB 78 0A 2C 78 90 1D 3F B3 37 38 76 85 11 A3 06 17 AF A0 1D

    EventSize - 0x00000008
0000: 4D654D6F64650000
  Event:
    PCRIndex  - 1
    EventType - 0x00DA0000
    DigestCount: 0x00000002
      HashAlgo : 0x0004
      Digest(0): 5B A9 3C 9D B0 CF F9 3F 52 B5 21 D7 42 0E 43 F6 ED A2 78 4F
      HashAlgo : 0x000B
      Digest(1): 6E 34 0B 9C FF B3 7A 98 9C A5 44 E6 BB 78 0A 2C 78 90 1D 3F B3 37 38 76 85 11 A3 06 17 AF A0 1D

    EventSize - 0x00000011
0000: 4F7074696F6E526F6D506F6C6963790000
  Event:
    PCRIndex  - 1
    EventType - 0x00DA0000
    DigestCount: 0x00000002
      HashAlgo : 0x0004
      Digest(0): 5B A9 3C 9D B0 CF F9 3F 52 B5 21 D7 42 0E 43 F6 ED A2 78 4F
      HashAlgo : 0x000B
      Digest(1): 6E 34 0B 9C FF B3 7A 98 9C A5 44 E6 BB 78 0A 2C 78 90 1D 3F B3 37 38 76 85 11 A3 06 17 AF A0 1D

    EventSize - 0x00000008
0000: 536D6D4277700000
```

Prefix of the first measured variable:
```
[~]$ echo 496F6D6D75436F6E666967 | xxd -r -p
IommuConfig
```

</p>
</details> 
