### PR TITLE
Rework the CPU throttling variables and setup UI management

### DIFF
--- a/DasharoModulePkg.dec
+++ b/DasharoModulePkg.dec
@@ -73,12 +73,13 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSerialRedirection2DefaultState|FALSE|BOOLEAN|0x00000001F
   gDasharoSystemFeaturesTokenSpaceGuid.PcdHave2ndUart|FALSE|BOOLEAN|0x000000021
   gDasharoSystemFeaturesTokenSpaceGuid.PcdOcWdtEnableDefault|FALSE|BOOLEAN|0x000000022
-  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuThrottlingThreshold|TRUE|BOOLEAN|0x00000023
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuThrottlingThreshold|FALSE|BOOLEAN|0x00000023
   gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuMaxTemperature|100|UINT8|0x00000024
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuMenu|FALSE|BOOLEAN|0x000000025
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuCoreDisable|FALSE|BOOLEAN|0x000000026
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuHyperThreading|FALSE|BOOLEAN|0x000000027
   gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuHyperThreadingDefault|TRUE|BOOLEAN|0x000000028
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuThrottlingOffsetDefault|20|UINT8|0x00000029
 
 [PcdsFixedAtBuild,PcdsPatchableInModule,PcdsDynamic,PcdsDynamicEx]
   ## Indicate whether the password is cleared.

--- a/Include/DasharoOptions.h
+++ b/Include/DasharoOptions.h
@@ -17,9 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Settings
 #define DASHARO_VAR_BATTERY_CONFIG                L"BatteryConfig"
 #define DASHARO_VAR_BOOT_MANAGER_ENABLED          L"BootManagerEnabled"
-#define DASHARO_VAR_CPU_MAX_TEMPERATURE           L"CpuMaxTemperature"
-#define DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD  L"CpuMinThrottlingThreshold"
-#define DASHARO_VAR_CPU_THROTTLING_THRESHOLD      L"CpuThrottlingThreshold"
+#define DASHARO_VAR_CPU_THROTTLING_OFFSET         L"CpuThrottlingOffset"
 #define DASHARO_VAR_ENABLE_CAMERA                 L"EnableCamera"
 #define DASHARO_VAR_ENABLE_WIFI_BT                L"EnableWifiBt"
 #define DASHARO_VAR_FAN_CURVE_OPTION              L"FanCurveOption"

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeatures.c
@@ -192,7 +192,9 @@ DasharoSystemFeaturesUiLibConstructor (
   PRIVATE_DATA(ShowPs2Option) = PcdGetBool (PcdShowPs2Option);
   PRIVATE_DATA(Have2ndUart) = PcdGetBool (PcdHave2ndUart);
   PRIVATE_DATA(ShowCpuThrottlingThreshold) = PcdGetBool (PcdShowCpuThrottlingThreshold);
+  PRIVATE_DATA(CpuMaxTemperature) = FixedPcdGet8 (PcdCpuMaxTemperature);
   PRIVATE_DATA(ShowCpuCoreDisable) = PcdGetBool(PcdShowCpuCoreDisable);
+  PRIVATE_DATA(ShowCpuHyperThreading) = PcdGetBool(PcdShowCpuHyperThreading);
   PRIVATE_DATA(ShowCpuHyperThreading) = PcdGetBool(PcdShowCpuHyperThreading);
 
   // Ensure at least one option is visible in given menu (if enabled), otherwise hide it
@@ -242,9 +244,7 @@ DasharoSystemFeaturesUiLibConstructor (
 
   LOAD_VAR (DASHARO_VAR_BATTERY_CONFIG, BatteryConfig);
   LOAD_VAR (DASHARO_VAR_BOOT_MANAGER_ENABLED, BootManagerEnabled);
-  LOAD_VAR (DASHARO_VAR_CPU_MAX_TEMPERATURE, CpuMaxTemperature);
-  LOAD_VAR (DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD, CpuMinThrottlingThreshold);
-  LOAD_VAR (DASHARO_VAR_CPU_THROTTLING_THRESHOLD, CpuThrottlingThreshold);
+  LOAD_VAR (DASHARO_VAR_CPU_THROTTLING_OFFSET, CpuThrottlingOffset);
   LOAD_VAR (DASHARO_VAR_ENABLE_CAMERA, EnableCamera);
   LOAD_VAR (DASHARO_VAR_ENABLE_WIFI_BT, EnableWifiBt);
   LOAD_VAR (DASHARO_VAR_FAN_CURVE_OPTION, FanCurveOption);
@@ -516,9 +516,7 @@ DasharoSystemFeaturesRouteConfig (
 
   STORE_VAR (DASHARO_VAR_BATTERY_CONFIG, BatteryConfig);
   STORE_VAR (DASHARO_VAR_BOOT_MANAGER_ENABLED, BootManagerEnabled);
-  STORE_VAR (DASHARO_VAR_CPU_MAX_TEMPERATURE, CpuMaxTemperature);
-  STORE_VAR (DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD, CpuMinThrottlingThreshold);
-  STORE_VAR (DASHARO_VAR_CPU_THROTTLING_THRESHOLD, CpuThrottlingThreshold);
+  STORE_VAR (DASHARO_VAR_CPU_THROTTLING_OFFSET, CpuThrottlingOffset);
   STORE_VAR (DASHARO_VAR_ENABLE_CAMERA, EnableCamera);
   STORE_VAR (DASHARO_VAR_ENABLE_WIFI_BT, EnableWifiBt);
   STORE_VAR (DASHARO_VAR_FAN_CURVE_OPTION, FanCurveOption);
@@ -632,6 +630,9 @@ DasharoSystemFeaturesCallback (
         break;
       case HYPER_THREADING_QUESTION_ID:
         Value->b = DasharoGetVariableDefault (DASHARO_VAR_HYPER_THREADING).Boolean;
+        break;
+      case CPU_THROTTLING_OFFSET_QUESTION_ID:
+        Value->u8 = DasharoGetVariableDefault (DASHARO_VAR_CPU_THROTTLING_OFFSET).Uint8;
         break;
       default:
         Status = EFI_UNSUPPORTED;

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesHii.h
@@ -82,8 +82,8 @@ typedef struct {
   BOOLEAN                  SerialPortRedirection;
   BOOLEAN                  SerialPort2Redirection;
   UINT8                    CpuThrottlingThreshold;
+  UINT8                    CpuThrottlingOffset;
   UINT8                    CpuMaxTemperature;
-  UINT8                    CpuMinThrottlingThreshold;
   BOOLEAN                  HybridCpuArchitecture;
   BOOLEAN                  HyperThreadingSupported;
   BOOLEAN                  HyperThreading;
@@ -148,5 +148,6 @@ typedef struct {
 #define SLEEP_TYPE_QUESTION_ID               0x800A
 #define SERIAL_PORT2_REDIR_QUESTION_ID       0x800B
 #define HYPER_THREADING_QUESTION_ID          0x800C
+#define CPU_THROTTLING_OFFSET_QUESTION_ID    0x800D
 
 #endif

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesStrings.uni
@@ -171,9 +171,12 @@
 #string STR_SERIAL_CONSOLE_REDIRECTION2_PROMPT   #language en-US  "Enable COM1 Serial Console Redirection"
 #string STR_SERIAL_CONSOLE_REDIRECTION2_HELP     #language en-US  "Redirect the firmware console to the second serial port."
 
-#string STR_CPU_THROTTLING_THRESHOLD_PROMPT      #language en-US  "CPU Throttling Threshold"
+#string STR_CPU_THROTTLING_THRESHOLD_PROMPT      #language en-US  "Current CPU Throttling Threshold Temperature"
 #string STR_CPU_THROTTLING_THRESHOLD_HELP        #language en-US  "The temperature above which the CPU will start throttling itself."
-#string STR_CPU_THROTTLING_THRESHOLD_RANGE_ERROR #language en-US  "The throttling threshold must be between TjMax - 63 and TjMax!!"
+
+#string STR_CPU_THROTTLING_OFFSET_PROMPT      #language en-US  "CPU Throttling Temperature Offset"
+#string STR_CPU_THROTTLING_OFFSET_HELP        #language en-US  "The temperature offset from TjMax (maximum CPU temperature) above which the CPU will start throttling itself.\n\n"
+                                                                  "The value is also known as TCC offset."
 
 #string STR_BIG_CORE_COUNT_PROMPT   #language en-US  "Number of active P-cores"
 #string STR_BIG_CORE_COUNT_HELP     #language en-US  "Specify the number of Performance cores that should remain active.\n\n"

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesUiLib.inf
@@ -94,3 +94,4 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuMenu
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuCoreDisable
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowCpuHyperThreading
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuMaxTemperature

--- a/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
+++ b/Library/DasharoSystemFeaturesUiLib/DasharoSystemFeaturesVfr.vfr
@@ -347,20 +347,30 @@ formset
     endif;
 
     suppressif ideqval FeaturesData.ShowCpuThrottlingThreshold == 0;
-        numeric varid   = FeaturesData.CpuThrottlingThreshold,
-                prompt  = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_PROMPT),
-                help    = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_HELP),
+        numeric varid   = FeaturesData.CpuThrottlingOffset,
+                questionid = CPU_THROTTLING_OFFSET_QUESTION_ID,
+                prompt  = STRING_TOKEN(STR_CPU_THROTTLING_OFFSET_PROMPT),
+                help    = STRING_TOKEN(STR_CPU_THROTTLING_OFFSET_HELP),
                 flags   = RESET_REQUIRED | INTERACTIVE,
-                minimum = 0, // Minimum threshold placeholder
-                maximum = 200, // Maximum threshold placeholder
+                minimum = 0,
+                maximum = 63,
                 step    = 1,
-                nosubmitif prompt = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_RANGE_ERROR),
-                    ideqid FeaturesData.CpuThrottlingThreshold > FeaturesData.CpuMaxTemperature
-                endif
-                nosubmitif prompt = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_RANGE_ERROR),
-                    ideqid FeaturesData.CpuThrottlingThreshold < FeaturesData.CpuMinThrottlingThreshold
-                endif
+
+                write   set(FeaturesData.CpuThrottlingThreshold, get(FeaturesData.CpuMaxTemperature) - pushthis);
+
         endnumeric;
+
+        grayoutif TRUE;
+          numeric varid   = FeaturesData.CpuThrottlingThreshold,
+                  prompt  = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_PROMPT),
+                  help    = STRING_TOKEN(STR_CPU_THROTTLING_THRESHOLD_HELP),
+                  minimum = 0,
+                  maximum = 255,
+
+                  read   get(FeaturesData.CpuMaxTemperature) - get(FeaturesData.CpuThrottlingOffset);
+
+          endnumeric;
+        endif;
     endif;
 
     subtitle text = STRING_TOKEN(STR_EMPTY_STRING);

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -38,9 +38,7 @@ typedef struct {
 STATIC CHAR16 *mAutoCreatedVariables[] = {
   DASHARO_VAR_BATTERY_CONFIG,
   DASHARO_VAR_BOOT_MANAGER_ENABLED,
-  DASHARO_VAR_CPU_MAX_TEMPERATURE,
-  DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD,
-  DASHARO_VAR_CPU_THROTTLING_THRESHOLD,
+  DASHARO_VAR_CPU_THROTTLING_OFFSET,
   DASHARO_VAR_ENABLE_CAMERA,
   DASHARO_VAR_ENABLE_WIFI_BT,
   DASHARO_VAR_FAN_CURVE_OPTION,
@@ -95,14 +93,8 @@ GetVariableInfo (
   } else if (StrCmp (VarName, DASHARO_VAR_BOOT_MANAGER_ENABLED) == 0) {
     Data.Boolean = TRUE;
     Size = sizeof (Data.Boolean);
-  } else if (StrCmp (VarName, DASHARO_VAR_CPU_MAX_TEMPERATURE) == 0) {
-    Data.Uint8 = FixedPcdGet8 (PcdCpuMaxTemperature);
-    Size = sizeof (Data.Uint8);
-  } else if (StrCmp (VarName, DASHARO_VAR_CPU_MIN_THROTTLING_THRESHOLD) == 0) {
-    Data.Uint8 = FixedPcdGet8 (PcdCpuMaxTemperature) - 63;
-    Size = sizeof (Data.Uint8);
-  } else if (StrCmp (VarName, DASHARO_VAR_CPU_THROTTLING_THRESHOLD) == 0) {
-    Data.Uint8 = 80;
+  } else if (StrCmp (VarName, DASHARO_VAR_CPU_THROTTLING_OFFSET) == 0) {
+    Data.Uint8 = FixedPcdGet8 (PcdCpuThrottlingOffsetDefault);
     Size = sizeof (Data.Uint8);
   } else if (StrCmp (VarName, DASHARO_VAR_ENABLE_CAMERA) == 0) {
     Data.Boolean = TRUE;

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -56,5 +56,6 @@
   gDasharoSystemFeaturesTokenSpaceGuid.PcdShowOcWdtOptions
   gDasharoSystemFeaturesTokenSpaceGuid.PcdSleepTypeDefaultS3
   gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuHyperThreadingDefault
+  gDasharoSystemFeaturesTokenSpaceGuid.PcdCpuThrottlingOffsetDefault
 
   gUefiPayloadPkgTokenSpaceGuid.PcdLoadOptionRoms


### PR DESCRIPTION
Reworked the CPU throttling to store the TCC offset directly. It allows to get around the nosubmitifs and set the fixed allowed range, which drastically simplifies the code and has better UX than some error pop-ups.

The current temperature threshold is still displayed as a grayed out numeric field.

Also fixed a couple of bugs:
1. Default value not restored properly.
2. Default value not passed from coreboot.
3. CPU maximum temperature not passed from coreboot (fixed on coreboot side).
4. Excessive use of variables for maximum and minimum temperature.