### PR TITLE
DasharoModulePkg/DasharoVariablesLib: fix build due to QuickSort()

### DIFF
--- a/Library/DasharoVariablesLib/DasharoVariablesLib.c
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.c
@@ -13,6 +13,7 @@
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
+#include <Library/SortLib.h>
 #include <Library/TpmMeasurementLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -380,7 +381,6 @@ MeasureVariables (
   EFI_GUID    Guid;
   CHAR16      **Names;
   UINTN       NameCount;
-  CHAR16      SortBuf;
   UINTN       MaxNameCount;
   UINTN       Index;
 
@@ -455,13 +455,7 @@ MeasureVariables (
     // Achieve predictable ordering of variables by sorting them by name within
     // a particular vendor.
     //
-    QuickSort (
-        Names,
-        NameCount,
-        sizeof (*Names),
-        CompareVariableNames,
-        &SortBuf
-        );
+    PerformQuickSort (Names, NameCount, sizeof (*Names), CompareVariableNames);
 
     for (Index = 0; Index < NameCount; Index++) {
       Status = MeasureVariable (Names[Index], Vendor);

--- a/Library/DasharoVariablesLib/DasharoVariablesLib.inf
+++ b/Library/DasharoVariablesLib/DasharoVariablesLib.inf
@@ -36,6 +36,7 @@
   DebugLib
   TpmMeasurementLib
   PcdLib
+  SortLib
   UefiLib
 
 [Guids]


### PR DESCRIPTION
The change ported from a newer EDK version used QuickSort() which doesn't exist in this one.

***

https://github.com/Dasharo/DasharoModulePkg/pull/52 didn't compile on this version of EDK...  This version does.